### PR TITLE
feat: Implement multi-server chat for Mindcraft bots

### DIFF
--- a/src/utils/unicode.js
+++ b/src/utils/unicode.js
@@ -1,0 +1,109 @@
+/**
+ * Encodes a string using Unicode zero-width characters.
+ * Converts the input text to its binary representation,
+ * and then uses U+200B for '0' and U+200C for '1'.
+ *
+ * @param {string} text The text to encode.
+ * @returns {string} The encoded string.
+ */
+function encodeText(text) {
+  let binaryText = '';
+  for (let i = 0; i < text.length; i++) {
+    binaryText += text[i].charCodeAt(0).toString(2).padStart(8, '0');
+  }
+
+  let encodedText = '';
+  for (let i = 0; i < binaryText.length; i++) {
+    if (binaryText[i] === '0') {
+      encodedText += '\u200B'; // Zero-width space
+    } else {
+      encodedText += '\u200C'; // Zero-width non-joiner
+    }
+  }
+  return encodedText;
+}
+
+/**
+ * Decodes a string encoded with Unicode zero-width characters.
+ * Converts the zero-width characters (U+200B for '0', U+200C for '1')
+ * back to a binary string, then to the original text.
+ *
+ * @param {string} encodedText The encoded string.
+ * @returns {string} The decoded string.
+ */
+function decodeText(encodedText) {
+  let binaryText = '';
+  for (let i = 0; i < encodedText.length; i++) {
+    if (encodedText[i] === '\u200B') {
+      binaryText += '0';
+    } else if (encodedText[i] === '\u200C') {
+      binaryText += '1';
+    }
+  }
+
+  let decodedText = '';
+  for (let i = 0; i < binaryText.length; i += 8) {
+    const byte = binaryText.substring(i, i + 8);
+    if (byte.length === 8) {
+      decodedText += String.fromCharCode(parseInt(byte, 2));
+    }
+  }
+  return decodedText;
+}
+
+/**
+ * Calculates the Jaro-Winkler similarity between two strings.
+ * @param {string} s1 The first string.
+ * @param {string} s2 The second string.
+ * @returns {number} The Jaro-Winkler similarity (0 to 1).
+ */
+function calculateSimilarity(s1, s2) {
+  if (s1 === s2) return 1.0;
+  if (!s1 || !s2) return 0.0;
+
+  const m = Math.max(s1.length, s2.length);
+  const range = Math.floor(m / 2) - 1;
+
+  const s1Matches = new Array(s1.length).fill(false);
+  const s2Matches = new Array(s2.length).fill(false);
+
+  let matches = 0;
+  for (let i = 0; i < s1.length; i++) {
+    const low = Math.max(0, i - range);
+    const high = Math.min(i + range + 1, s2.length);
+    for (let j = low; j < high; j++) {
+      if (!s2Matches[j] && s1[i] === s2[j]) {
+        s1Matches[i] = true;
+        s2Matches[j] = true;
+        matches++;
+        break;
+      }
+    }
+  }
+
+  if (matches === 0) return 0.0;
+
+  let t = 0;
+  let k = 0;
+  for (let i = 0; i < s1.length; i++) {
+    if (s1Matches[i]) {
+      while (!s2Matches[k]) k++;
+      if (s1[i] !== s2[k]) t++;
+      k++;
+    }
+  }
+  t /= 2;
+
+  const jaro = (matches / s1.length + matches / s2.length + (matches - t) / matches) / 3;
+
+  // Winkler modification
+  let l = 0; // length of common prefix
+  const p = 0.1; // scaling factor
+  while (s1[l] === s2[l] && l < Math.min(s1.length, s2.length, 4)) {
+    l++;
+  }
+
+  return jaro + l * p * (1 - jaro);
+}
+
+export { encodeText, decodeText, calculateSimilarity };

--- a/tests/unit/unicode.test.js
+++ b/tests/unit/unicode.test.js
@@ -1,0 +1,142 @@
+import assert from 'assert';
+import { encodeText, decodeText, calculateSimilarity } from '../../src/utils/unicode.js';
+
+// Helper for logging test sections
+function describe(description, fn) {
+    console.log(`\n--- ${description} ---`);
+    fn();
+}
+
+// Helper for individual tests
+function it(description, fn) {
+    try {
+        fn();
+        console.log(`  ✓ ${description}`);
+    } catch (error) {
+        console.error(`  ✗ ${description}`);
+        console.error(error);
+    }
+}
+
+describe('Unicode Encoding/Decoding', () => {
+    const testCases = [
+        { name: "Empty string", input: "" },
+        { name: "Simple short string", input: "hello" },
+        { name: "String with spaces", input: "hello world" },
+        { name: "String with numbers", input: "12345" },
+        { name: "String with symbols", input: "!@#$%^&*()" },
+        { name: "String with mixed content", input: "Hello 123 !@#" },
+        { name: "Longer string", input: "This is a longer test string with various characters to ensure robustness." }
+    ];
+
+    testCases.forEach(tc => {
+        it(`should correctly encode and decode: ${tc.name} ("${tc.input}")`, () => {
+            const encoded = encodeText(tc.input);
+            const decoded = decodeText(encoded);
+            assert.strictEqual(decoded, tc.input, `Failed for input: ${tc.input}`);
+        });
+    });
+
+    it('decodeText should return empty string for non-zero-width char strings', () => {
+        const decoded = decodeText("completely normal text");
+        assert.strictEqual(decoded, "", "Should be empty for non-encoded string");
+    });
+
+    it('decodeText should return empty string for random unicode chars not part of encoding', () => {
+        const decoded = decodeText("\u0041\u0042\u0043"); // "ABC"
+        assert.strictEqual(decoded, "", "Should be empty for other unicode chars");
+    });
+
+    it('decodeText should handle mixed valid and invalid content (partial decoding)', () => {
+        const validPart = encodeText("hi");
+        const invalidPart = "普通文字"; // "Normal text" in Chinese
+
+        const decodedPrefix = decodeText(validPart + invalidPart);
+        assert.strictEqual(decodedPrefix, "hi", "Should decode the valid prefix part when invalid follows");
+
+        const decodedSuffix = decodeText(invalidPart + validPart);
+        // Current unicode.js decodeText will skip over non-mapping characters.
+        // So if invalidPart contains no zero-width spaces/non-joiners, it will be skipped.
+        assert.strictEqual(decodedSuffix, "hi", "Should skip leading invalid part and decode valid suffix");
+
+        const mixedInMiddle = encodeText("h") + invalidPart + encodeText("i");
+        assert.strictEqual(decodeText(mixedInMiddle), "hi", "Should skip invalid part in the middle");
+
+    });
+
+    it('decodeText should handle strings with only one type of zero-width char', () => {
+        const allZeros = '\u200B\u200B\u200B\u200B\u200B\u200B\u200B\u200B'; // Represents a null byte (0x00)
+        const decodedZeros = decodeText(allZeros);
+        assert.strictEqual(decodedZeros, String.fromCharCode(0), "Should decode string of U+200B (zeros)");
+
+        const allOnes = '\u200C\u200C\u200C\u200C\u200C\u200C\u200C\u200C'; // Represents 0xFF
+        const decodedOnes = decodeText(allOnes);
+        assert.strictEqual(decodedOnes, String.fromCharCode(255), "Should decode string of U+200C (ones)");
+    });
+
+     it('decodeText should handle incomplete byte at the end gracefully', () => {
+        const encodedHello = encodeText("hello");
+        const incompleteEncoded = encodedHello.substring(0, encodedHello.length - 3); // Remove last 3 zero-width chars
+        const decoded = decodeText(incompleteEncoded);
+        // "hell" should be decoded, the last partial 'o' should be ignored.
+        assert.strictEqual(decoded, "hell", "Should decode up to the last complete byte");
+    });
+});
+
+describe('Jaro-Winkler Similarity Calculation', () => {
+    it('should return 1.0 for identical strings', () => {
+        assert.strictEqual(calculateSimilarity("test", "test"), 1.0);
+        assert.strictEqual(calculateSimilarity("", ""), 1.0);
+        assert.strictEqual(calculateSimilarity("long string test", "long string test"), 1.0);
+    });
+
+    it('should return 0.0 for completely different strings (or very low for Jaro-Winkler)', () => {
+        assert.ok(calculateSimilarity("apple", "banana") < 0.7, "apple vs banana should be low"); // Jaro-Winkler gives non-zero due to 'a'
+        assert.strictEqual(calculateSimilarity("abc", "xyz"), 0.0, "abc vs xyz should be 0.0");
+    });
+
+    it('should return high similarity for very similar strings', () => {
+        assert.ok(calculateSimilarity("test", "tets") > 0.8, "test vs tets"); // High similarity
+        assert.ok(calculateSimilarity("apple", "apply") > 0.85, "apple vs apply"); // apply vs apple, m=2 ('a','p'), t=0. jaro = (2/5+2/5+(2-0)/2)/3 = (0.4+0.4+1)/3 = 1.8/3=0.6. l=1 ('a'). JW = 0.6 + 1*0.1*(1-0.6) = 0.6 + 0.04 = 0.64 -- this seems low, will check my formula understanding.
+        // My Jaro-Winkler understanding or example values might be slightly off, the key is "high similarity"
+        // For "apple" vs "apply": s1_matches = [t,t,t,f,t], s2_matches = [t,t,t,f,t]. m=4.
+        // s1: a p p l e
+        // s2: a p p y e
+        // matches: a,p,p,e (m=4).
+        // transpositions: 'l' vs 'y' is not a transposition as they are different characters. So t=0.
+        // Jaro = (4/5 + 4/5 + (4-0)/4) / 3 = (0.8 + 0.8 + 1) / 3 = 2.6 / 3 = 0.8666...
+        // Common prefix 'app', l=3.
+        // JW = Jaro + l * p * (1 - Jaro) = 0.8666 + 3 * 0.1 * (1 - 0.8666) = 0.8666 + 0.3 * 0.1333 = 0.8666 + 0.03999 = 0.90665
+        assert.ok(calculateSimilarity("apple", "apply") > 0.9, "apple vs apply");
+
+
+        assert.ok(calculateSimilarity("martha", "marhta") > 0.95, "martha vs marhta"); // Transposition: (m=6, t=1) Jaro=(6/6+6/6+(6-1)/6)/3 = (1+1+5/6)/3 = (2+0.833)/3 = 2.833/3 = 0.944. l=3. JW = 0.944 + 3*0.1*(1-0.944) = 0.944 + 0.3*0.056 = 0.944 + 0.0168 = 0.9608
+        assert.ok(calculateSimilarity("dwayne", "duane") > 0.8, "dwayne vs duane");
+    });
+
+    it('should handle strings of different lengths', () => {
+        assert.ok(calculateSimilarity("test", "testing") > 0.8, "test vs testing"); // Jaro: m=4. (4/4 + 4/7 + (4-0)/4)/3 = (1+0.571+1)/3 = 2.571/3 = 0.857. l=4. JW = 0.857 + 4*0.1*(1-0.857) = 0.857 + 0.4*0.143 = 0.857 + 0.0572 = 0.9142
+        assert.ok(calculateSimilarity("verylongstring", "short") < 0.6, "verylongstring vs short");
+    });
+
+    it('should handle empty string as one or both inputs', () => {
+        assert.strictEqual(calculateSimilarity("test", ""), 0.0, "test vs empty");
+        assert.strictEqual(calculateSimilarity("", "test"), 0.0, "empty vs test");
+        assert.strictEqual(calculateSimilarity("", ""), 1.0, "empty vs empty - already tested but good for completeness here");
+    });
+
+    it('should respect the prefix bonus for Jaro-Winkler', () => {
+        // Jaro for "abc" vs "abd": m=2 ('a','b'), t=0. (2/3 + 2/3 + (2-0)/2)/3 = (0.666+0.666+1)/3 = 2.333/3 = 0.777...
+        // l=2 ('ab'). JW = 0.777 + 2*0.1*(1-0.777) = 0.777 + 0.2*0.222 = 0.777 + 0.0444 = 0.8214...
+        const score_abc_abd = calculateSimilarity("abc", "abd");
+
+        // Jaro for "acb" vs "adb": m=2 ('a','b'), t=0. (2/3 + 2/3 + (2-0)/2)/3 = 0.777...
+        // l=1 ('a'). JW = 0.777 + 1*0.1*(1-0.777) = 0.777 + 0.1*0.222 = 0.777 + 0.0222 = 0.7992...
+        const score_acb_adb = calculateSimilarity("acb", "adb");
+
+        assert.ok(score_abc_abd > score_acb_adb, `Prefix bonus: 'abc'/'abd' (${score_abc_abd}) > 'acb'/'adb' (${score_acb_adb})`);
+        assert.ok(calculateSimilarity("johnson", "johsnson") > 0.9, "johnson vs johsnson with prefix");
+    });
+});
+
+console.log("\nUnicode utility tests completed. Check for any '✗' indicating failures.");


### PR DESCRIPTION
This feature enables Mindcraft bots running on the same server to detect each other and establish direct communication channels.

Key changes:
- Agents send a Unicode-encoded "PING" message (invisible to players) upon spawning.
- Agents listen for and decode these PINGs to identify other bots. String similarity (Jaro-Winkler) is used for robust detection.
- A handshake protocol using JSON payloads (`INITIATE_CONNECTION`, `ACKNOWLEDGE_CONNECTION`) sent via Minecraft's whisper command (`/msg`) establishes a confirmed connection between two bots.
- Connected bots are tracked in a `nearbyBots` list within the `ConversationManager`.
- Subsequent chat between connected bots uses JSON payloads (`BOT_CHAT_MESSAGE`) also sent via whisper, integrating with the existing `ConversationManager` logic.
- Unicode encoding/decoding utilities are added in `src/utils/unicode.js`.
- Unit tests for Unicode utilities are included in `tests/unit/unicode.test.js`.
- `agent.js` and `conversation.js` were significantly updated to support these new detection, connection, and communication mechanisms.