### PR TITLE
Fix: Set agents to 2 in tasks/construction_tasks/custom/church_two_agents.json

### DIFF
--- a/tasks/construction_tasks/custom/church_two_agents.json
+++ b/tasks/construction_tasks/custom/church_two_agents.json
@@ -3,7 +3,7 @@
       "type": "construction",
       "goal": "Make a structure with the blueprint below",
       "conversation": "Let's share materials and make a structure with the blueprint",
-      "agent_count": 1,
+      "agent_count": 2,
       "timeout": 1000,
       "blueprint": {
         "materials": {


### PR DESCRIPTION
This patch fixes a bug in tasks/construction_tasks/custom/church_two_agents.json
where only one agent was created (agents = 1), even though two were expected.

- Updated the "agents" value from 1 to 2.
- Ensures that the multi-agent scenario now starts with both agents active.