### PR TITLE
fix listen host with docker env

### DIFF
--- a/src/mindcraft/mindserver.js
+++ b/src/mindcraft/mindserver.js
@@ -279,7 +279,7 @@ export function createMindServer(host_public = false, port = 8080) {
     if (host_public) {
         console.log('Public hosting not supported yet. Using localhost.');
     }
-    const host = 'localhost';
+    const host = '0.0.0.0';
     server.listen(port, host, () => {
         console.log(`MindServer running on port ${port} on host ${host}`);
     });


### PR DESCRIPTION
## Problem

When running MindCraft inside a Docker container, the MindServer fails to
accept connections from child agent processes:

MindServer running on port 8080 on host localhost
Connecting to MindServer
Connection failed: TransportError: xhr poll error
Error: connect ECONNREFUSED 127.0.0.1:8080

**Cause:** `src/mindcraft/mindserver.js:282` binds the HTTP server to
`localhost`. Inside Docker, this resolves to the container's loopback
interface (`127.0.0.1`), which is not accessible from child processes
spawned by the main process — even within the same container.

## Fix

Changed the listen host from `localhost` to `0.0.0.0`:

```diff
- const host = 'localhost';
+ const host = '0.0.0.0';
0.0.0.0 binds to all available network interfaces inside the container,
which is the standard practice for services running in containers.
Testing
1. docker compose up --build
2. MindServer starts on 0.0.0.0:8080
3. Agent processes connect without ECONNREFUSED
No impact on non-Docker usage — in both cases the server is reachable
from the local machine.