### PR TITLE
Route Mindcraft through Andy preference router

### DIFF
--- a/andy.json
+++ b/andy.json
@@ -1,7 +1,7 @@
 {
     "name": "andy",
 
-    "model": "andy/auto",
-    "embedding": "andy/auto"
+    "model": "andy/auto/mindcraft",
+    "embedding": "andy/auto/mindcraft"
 
 }


### PR DESCRIPTION
## What changed

- Route Mindcraft chat requests through `andy/auto/mindcraft`.
- Route Mindcraft embedding requests through the same tagged Andy API router.

## Why

Andy API's preference-router release is now live and production-verified. The `mindcraft` tag places `andy-4.2` first while retaining the complete eligible failover tail.

## Verification

- Andy API production health and both model API routes return 200.
- `auto/mindcraft` completed a live moderated request and successfully failed over on the second provider attempt.
- The production Models page reports `andy-4.2` first for `auto/mindcraft`, followed by the neutral fallback pool.
- `andy.json` parses as JSON and both IDs equal `andy/auto/mindcraft`.
