### PR TITLE
Handle truncated OpenAI-compatible responses without disconnect errors

### DIFF
--- a/src/models/gpt.js
+++ b/src/models/gpt.js
@@ -22,14 +22,8 @@ export class GPT {
     }
 
     async sendRequest(turns, systemMessage, stop_seq='***') {
-        let messages = strictFormat(turns);
-        messages = messages.map(message => {
-            message.content += stop_seq;
-            return message;
-        });
-        let model = this.model_name || "gpt-5.4-mini";
-
-        let res = null;
+        const model = this.model_name || "gpt-5.4-mini";
+        let res;
 
         try {
             console.log('Awaiting openai api response from model', model);
@@ -47,12 +41,12 @@ export class GPT {
                 if (model.includes('o1') || model.includes('o3') || model.includes('5')) {
                     delete pack.stop;
                 }
-                let completion = await this.openai.chat.completions.create(pack);
+                const completion = await this.openai.chat.completions.create(pack);
                 if (completion.choices[0].finish_reason == 'length')
                     console.warn('Model response stopped with finish_reason=length; returning partial response.');
                 console.log('Received.');
                 res = completion.choices[0].message.content;
-            } 
+            }
             // otherwise, use responses
             else {
                 let messages = strictFormat(turns);
@@ -68,7 +62,7 @@ export class GPT {
                 });
                 console.log('Received.');
                 res = response.output_text;
-                let stop_seq_index = res.indexOf(stop_seq);
+                const stop_seq_index = res.indexOf(stop_seq);
                 res = stop_seq_index !== -1 ? res.slice(0, stop_seq_index) : res;
             }
         }
@@ -87,7 +81,7 @@ export class GPT {
         return res;
     }
 
-    async sendVisionRequest(messages, systemMessage, imageBuffer) {
+    sendVisionRequest(messages, systemMessage, imageBuffer) {
         const imageMessages = [...messages];
         imageMessages.push({
             role: "user",
@@ -99,7 +93,7 @@ export class GPT {
                 }
             ]
         });
-        
+
         return this.sendRequest(imageMessages, systemMessage);
     }
 
@@ -121,7 +115,7 @@ const sendAudioRequest = async (text, model, voice, url) => {
         model: model,
         voice: voice,
         input: text
-    }
+    };
 
     let config = {};
 
@@ -139,9 +133,9 @@ const sendAudioRequest = async (text, model, voice, url) => {
     const buffer = Buffer.from(await mp3.arrayBuffer());
     const base64 = buffer.toString("base64");
     return base64;
-}
+};
 
 export const TTSConfig = {
     sendAudioRequest: sendAudioRequest,
     baseUrl: 'https://api.openai.com/v1',
-}
+};

--- a/src/models/gpt.js
+++ b/src/models/gpt.js
@@ -49,7 +49,7 @@ export class GPT {
                 }
                 let completion = await this.openai.chat.completions.create(pack);
                 if (completion.choices[0].finish_reason == 'length')
-                    throw new Error('Context length exceeded'); 
+                    console.warn('Model response stopped with finish_reason=length; returning partial response.');
                 console.log('Received.');
                 res = completion.choices[0].message.content;
             } 

--- a/src/models/gpt.js
+++ b/src/models/gpt.js
@@ -9,7 +9,7 @@ export class GPT {
         this.params = params;
         this.url = url; // store so that we know whether a custom URL has been set
 
-        let config = {};
+        const config = {};
         if (url)
             config.baseURL = url;
 
@@ -22,14 +22,8 @@ export class GPT {
     }
 
     async sendRequest(turns, systemMessage, stop_seq='***') {
-        let messages = strictFormat(turns);
-        messages = messages.map(message => {
-            message.content += stop_seq;
-            return message;
-        });
-        let model = this.model_name || "gpt-5.4-mini";
-
-        let res = null;
+        const model = this.model_name || "gpt-5.4-mini";
+        let res;
 
         try {
             console.log('Awaiting openai api response from model', model);
@@ -47,12 +41,12 @@ export class GPT {
                 if (model.includes('o1') || model.includes('o3') || model.includes('5')) {
                     delete pack.stop;
                 }
-                let completion = await this.openai.chat.completions.create(pack);
+                const completion = await this.openai.chat.completions.create(pack);
                 if (completion.choices[0].finish_reason == 'length')
                     console.warn('Model response stopped with finish_reason=length; returning partial response.');
                 console.log('Received.');
                 res = completion.choices[0].message.content;
-            } 
+            }
             // otherwise, use responses
             else {
                 let messages = strictFormat(turns);
@@ -68,7 +62,7 @@ export class GPT {
                 });
                 console.log('Received.');
                 res = response.output_text;
-                let stop_seq_index = res.indexOf(stop_seq);
+                const stop_seq_index = res.indexOf(stop_seq);
                 res = stop_seq_index !== -1 ? res.slice(0, stop_seq_index) : res;
             }
         }
@@ -87,7 +81,7 @@ export class GPT {
         return res;
     }
 
-    async sendVisionRequest(messages, systemMessage, imageBuffer) {
+    sendVisionRequest(messages, systemMessage, imageBuffer) {
         const imageMessages = [...messages];
         imageMessages.push({
             role: "user",
@@ -99,7 +93,7 @@ export class GPT {
                 }
             ]
         });
-        
+
         return this.sendRequest(imageMessages, systemMessage);
     }
 
@@ -121,9 +115,9 @@ const sendAudioRequest = async (text, model, voice, url) => {
         model: model,
         voice: voice,
         input: text
-    }
+    };
 
-    let config = {};
+    const config = {};
 
     if (url)
         config.baseURL = url;
@@ -139,9 +133,9 @@ const sendAudioRequest = async (text, model, voice, url) => {
     const buffer = Buffer.from(await mp3.arrayBuffer());
     const base64 = buffer.toString("base64");
     return base64;
-}
+};
 
 export const TTSConfig = {
     sendAudioRequest: sendAudioRequest,
     baseUrl: 'https://api.openai.com/v1',
-}
+};

--- a/src/models/gpt.js
+++ b/src/models/gpt.js
@@ -22,8 +22,14 @@ export class GPT {
     }
 
     async sendRequest(turns, systemMessage, stop_seq='***') {
-        const model = this.model_name || "gpt-5.4-mini";
-        let res;
+        let messages = strictFormat(turns);
+        messages = messages.map(message => {
+            message.content += stop_seq;
+            return message;
+        });
+        let model = this.model_name || "gpt-5.4-mini";
+
+        let res = null;
 
         try {
             console.log('Awaiting openai api response from model', model);
@@ -41,12 +47,12 @@ export class GPT {
                 if (model.includes('o1') || model.includes('o3') || model.includes('5')) {
                     delete pack.stop;
                 }
-                const completion = await this.openai.chat.completions.create(pack);
+                let completion = await this.openai.chat.completions.create(pack);
                 if (completion.choices[0].finish_reason == 'length')
                     console.warn('Model response stopped with finish_reason=length; returning partial response.');
                 console.log('Received.');
                 res = completion.choices[0].message.content;
-            }
+            } 
             // otherwise, use responses
             else {
                 let messages = strictFormat(turns);
@@ -62,7 +68,7 @@ export class GPT {
                 });
                 console.log('Received.');
                 res = response.output_text;
-                const stop_seq_index = res.indexOf(stop_seq);
+                let stop_seq_index = res.indexOf(stop_seq);
                 res = stop_seq_index !== -1 ? res.slice(0, stop_seq_index) : res;
             }
         }
@@ -81,7 +87,7 @@ export class GPT {
         return res;
     }
 
-    sendVisionRequest(messages, systemMessage, imageBuffer) {
+    async sendVisionRequest(messages, systemMessage, imageBuffer) {
         const imageMessages = [...messages];
         imageMessages.push({
             role: "user",
@@ -93,7 +99,7 @@ export class GPT {
                 }
             ]
         });
-
+        
         return this.sendRequest(imageMessages, systemMessage);
     }
 
@@ -115,7 +121,7 @@ const sendAudioRequest = async (text, model, voice, url) => {
         model: model,
         voice: voice,
         input: text
-    };
+    }
 
     let config = {};
 
@@ -133,9 +139,9 @@ const sendAudioRequest = async (text, model, voice, url) => {
     const buffer = Buffer.from(await mp3.arrayBuffer());
     const base64 = buffer.toString("base64");
     return base64;
-};
+}
 
 export const TTSConfig = {
     sendAudioRequest: sendAudioRequest,
     baseUrl: 'https://api.openai.com/v1',
-};
+}

--- a/tests/gpt_truncated_response.test.js
+++ b/tests/gpt_truncated_response.test.js
@@ -1,0 +1,25 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { GPT } from '../src/models/gpt.js';
+
+test('OpenAI-compatible finish_reason=length preserves partial response content', async () => {
+    const model = Object.create(GPT.prototype);
+    model.model_name = 'local-model';
+    model.params = {};
+    model.url = 'http://localhost:1234/v1';
+    model.openai = {
+        chat: {
+            completions: {
+                create: async () => ({
+                    choices: [{
+                        finish_reason: 'length',
+                        message: { content: 'usable partial response' },
+                    }],
+                }),
+            },
+        },
+    };
+
+    const result = await model.sendRequest([], 'system prompt');
+    assert.equal(result, 'usable partial response');
+});

--- a/tests/gpt_truncated_response.test.js
+++ b/tests/gpt_truncated_response.test.js
@@ -10,7 +10,7 @@ test('OpenAI-compatible finish_reason=length preserves partial response content'
     model.openai = {
         chat: {
             completions: {
-                create: async () => ({
+                create: () => Promise.resolve({
                     choices: [{
                         finish_reason: 'length',
                         message: { content: 'usable partial response' },


### PR DESCRIPTION
## Merge status

**BLOCKED BY:** None

This PR has no known dependency on another PR in the #59-#90 series.

## Summary
Treat `finish_reason: "length"` from OpenAI-compatible chat completions as a usable truncated response instead of turning it into a generic "brain disconnected" failure.

## Why
Local and OpenAI-compatible models can legitimately hit an output-token cap while still returning useful content. Throwing the response away causes unnecessary retries and makes the agent appear disconnected.

## Changes
- Preserve usable partial content when generation ends because of the output-token limit.
- Keep context-length retry handling separate from output truncation.
- Avoid converting valid truncated generations into a generic provider failure.

## Scope
Provider response handling only; no model, prompt, or gameplay behavior changes.