### PR TITLE
Centralize reasoning-output cleanup across conversation and memory prompts

### DIFF
--- a/src/models/prompter.js
+++ b/src/models/prompter.js
@@ -179,9 +179,9 @@ export class Prompter {
             let goal_text = '';
             for (let goal in last_goals) {
                 if (last_goals[goal])
-                    goal_text += `You recently successfully completed the goal ${goal}.\n`
+                    goal_text += `You recently successfully completed the goal ${goal}.\n`;
                 else
-                    goal_text += `You recently failed to complete the goal ${goal}.\n`
+                    goal_text += `You recently failed to complete the goal ${goal}.\n`;
             }
             prompt = prompt.replaceAll('$LAST_GOALS', goal_text.trim());
         }
@@ -315,7 +315,7 @@ export class Prompter {
         system_message = await this.replaceStrings(system_message, messages);
 
         let user_message = 'Use the below info to determine what goal to target next\n\n';
-        user_message += '$LAST_GOALS\n$STATS\n$INVENTORY\n$CONVO'
+        user_message += '$LAST_GOALS\n$STATS\n$INVENTORY\n$CONVO';
         user_message = await this.replaceStrings(user_message, messages, null, null, last_goals);
         let user_messages = [{role: 'user', content: user_message}];
 

--- a/src/models/prompter.js
+++ b/src/models/prompter.js
@@ -211,6 +211,16 @@ export class Prompter {
         this.last_prompt_time = Date.now();
     }
 
+    _cleanReasoningOutput(generation) {
+        if (typeof generation !== 'string')
+            return generation;
+
+        if (generation.includes('</think>'))
+            generation = generation.split('</think>').pop();
+
+        return generation.replace(/\*{3,}\s*$/g, '').trim();
+    }
+
     async promptConvo(messages) {
         this.most_recent_msg_time = Date.now();
         let current_msg_time = this.most_recent_msg_time;
@@ -250,11 +260,7 @@ export class Prompter {
                 return '';
             }
 
-            if (generation?.includes('</think>')) {
-                const [_, afterThink] = generation.split('</think>')
-                generation = afterThink
-            }
-
+            generation = this._cleanReasoningOutput(generation);
             return generation;
         }
 
@@ -283,11 +289,7 @@ export class Prompter {
         prompt = await this.replaceStrings(prompt, null, null, to_summarize);
         let resp = await this.chat_model.sendRequest([], prompt);
         await this._saveLog(prompt, to_summarize, resp, 'memSaving');
-        if (resp?.includes('</think>')) {
-            const [_, afterThink] = resp.split('</think>')
-            resp = afterThink;
-        }
-        return resp;
+        return this._cleanReasoningOutput(resp);
     }
 
     async promptShouldRespondToBot(new_message) {

--- a/src/models/prompter.js
+++ b/src/models/prompter.js
@@ -218,7 +218,7 @@ export class Prompter {
         if (generation.includes('</think>'))
             generation = generation.split('</think>').pop();
 
-        return generation.replace(/\*{3,}\s*$/g, '').trim();
+        return generation.trim();
     }
 
     async promptConvo(messages) {

--- a/tests/reasoning_output.test.js
+++ b/tests/reasoning_output.test.js
@@ -1,0 +1,14 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { Prompter } from '../src/models/prompter.js';
+
+const clean = (value) => Prompter.prototype._cleanReasoningOutput(value);
+
+test('reasoning cleanup removes hidden think content', () => {
+    assert.equal(clean('<think>private</think>visible'), 'visible');
+    assert.equal(clean('<think>a</think>first</think>last'), 'last');
+});
+
+test('reasoning cleanup preserves legitimate trailing markdown', () => {
+    assert.equal(clean('answer\n***'), 'answer\n***');
+});


### PR DESCRIPTION
## Merge status

**BLOCKED BY:** None

This PR has no known dependency on another PR in the #59-#90 series.

## Summary
Centralize cleanup of model reasoning delimiters and trailing prompt markers so reasoning-capable models return clean user-facing content.

## Why
Reasoning-capable models may emit `</think>` or trailing separator text in more than one prompt path. Duplicated ad-hoc cleanup can behave inconsistently.

## Changes
- Add one reusable reasoning-output cleanup helper.
- Apply it to normal conversation output.
- Apply the same cleanup to memory-summary output.
- Keep the existing generation/retry flow intact.

## Scope
Output post-processing only.