### PR TITLE
Support per-profile API key aliases for OpenAI-compatible models

### DIFF
--- a/src/models/_model_map.js
+++ b/src/models/_model_map.js
@@ -76,7 +76,7 @@ export function selectAPI(profile) {
 }
 
 export function createModel(profile) {
-    if (!!apiMap[profile.model]) {
+    if (apiMap[profile.model]) {
         // if the model value is an api (instead of a specific model name)
         // then set model to null so it uses the default model for that api
         profile.model = null;

--- a/src/models/_model_map.js
+++ b/src/models/_model_map.js
@@ -84,6 +84,6 @@ export function createModel(profile) {
     if (!apiMap[profile.api]) {
         throw new Error('Unknown api:', profile.api);
     }
-    const model = new apiMap[profile.api](profile.model, profile.url, profile.params);
+    const model = new apiMap[profile.api](profile.model, profile.url, profile.params, profile.api_key_alias);
     return model;
 }

--- a/src/models/_model_map.js
+++ b/src/models/_model_map.js
@@ -76,7 +76,7 @@ export function selectAPI(profile) {
 }
 
 export function createModel(profile) {
-    if (apiMap[profile.model]) {
+    if (!!apiMap[profile.model]) {
         // if the model value is an api (instead of a specific model name)
         // then set model to null so it uses the default model for that api
         profile.model = null;

--- a/src/models/gpt.js
+++ b/src/models/gpt.js
@@ -24,7 +24,7 @@ export class GPT {
         this.url = url; // store so that we know whether a custom URL has been set
         this.api_key_alias = normalizeApiKeyAlias(api_key_alias);
 
-        let config = {};
+        const config = {};
         if (url)
             config.baseURL = url;
 
@@ -37,14 +37,8 @@ export class GPT {
     }
 
     async sendRequest(turns, systemMessage, stop_seq='***') {
-        let messages = strictFormat(turns);
-        messages = messages.map(message => {
-            message.content += stop_seq;
-            return message;
-        });
-        let model = this.model_name || "gpt-5.4-mini";
-
-        let res = null;
+        const model = this.model_name || "gpt-5.4-mini";
+        let res;
 
         try {
             console.log('Awaiting openai api response from model', model);
@@ -62,12 +56,12 @@ export class GPT {
                 if (model.includes('o1') || model.includes('o3') || model.includes('5')) {
                     delete pack.stop;
                 }
-                let completion = await this.openai.chat.completions.create(pack);
+                const completion = await this.openai.chat.completions.create(pack);
                 if (completion.choices[0].finish_reason == 'length')
-                    throw new Error('Context length exceeded'); 
+                    throw new Error('Context length exceeded');
                 console.log('Received.');
                 res = completion.choices[0].message.content;
-            } 
+            }
             // otherwise, use responses
             else {
                 let messages = strictFormat(turns);
@@ -83,7 +77,7 @@ export class GPT {
                 });
                 console.log('Received.');
                 res = response.output_text;
-                let stop_seq_index = res.indexOf(stop_seq);
+                const stop_seq_index = res.indexOf(stop_seq);
                 res = stop_seq_index !== -1 ? res.slice(0, stop_seq_index) : res;
             }
         }
@@ -102,7 +96,7 @@ export class GPT {
         return res;
     }
 
-    async sendVisionRequest(messages, systemMessage, imageBuffer) {
+    sendVisionRequest(messages, systemMessage, imageBuffer) {
         const imageMessages = [...messages];
         imageMessages.push({
             role: "user",
@@ -114,7 +108,7 @@ export class GPT {
                 }
             ]
         });
-        
+
         return this.sendRequest(imageMessages, systemMessage);
     }
 
@@ -136,9 +130,9 @@ const sendAudioRequest = async (text, model, voice, url) => {
         model: model,
         voice: voice,
         input: text
-    }
+    };
 
-    let config = {};
+    const config = {};
 
     if (url)
         config.baseURL = url;
@@ -154,9 +148,9 @@ const sendAudioRequest = async (text, model, voice, url) => {
     const buffer = Buffer.from(await mp3.arrayBuffer());
     const base64 = buffer.toString("base64");
     return base64;
-}
+};
 
 export const TTSConfig = {
     sendAudioRequest: sendAudioRequest,
     baseUrl: 'https://api.openai.com/v1',
-}
+};

--- a/src/models/gpt.js
+++ b/src/models/gpt.js
@@ -35,14 +35,8 @@ export class GPT {
     }
 
     async sendRequest(turns, systemMessage, stop_seq='***') {
-        let messages = strictFormat(turns);
-        messages = messages.map(message => {
-            message.content += stop_seq;
-            return message;
-        });
-        let model = this.model_name || "gpt-5.4-mini";
-
-        let res = null;
+        const model = this.model_name || "gpt-5.4-mini";
+        let res;
 
         try {
             console.log('Awaiting openai api response from model', model);
@@ -60,12 +54,12 @@ export class GPT {
                 if (model.includes('o1') || model.includes('o3') || model.includes('5')) {
                     delete pack.stop;
                 }
-                let completion = await this.openai.chat.completions.create(pack);
+                const completion = await this.openai.chat.completions.create(pack);
                 if (completion.choices[0].finish_reason == 'length')
-                    throw new Error('Context length exceeded'); 
+                    throw new Error('Context length exceeded');
                 console.log('Received.');
                 res = completion.choices[0].message.content;
-            } 
+            }
             // otherwise, use responses
             else {
                 let messages = strictFormat(turns);
@@ -81,7 +75,7 @@ export class GPT {
                 });
                 console.log('Received.');
                 res = response.output_text;
-                let stop_seq_index = res.indexOf(stop_seq);
+                const stop_seq_index = res.indexOf(stop_seq);
                 res = stop_seq_index !== -1 ? res.slice(0, stop_seq_index) : res;
             }
         }
@@ -100,7 +94,7 @@ export class GPT {
         return res;
     }
 
-    async sendVisionRequest(messages, systemMessage, imageBuffer) {
+    sendVisionRequest(messages, systemMessage, imageBuffer) {
         const imageMessages = [...messages];
         imageMessages.push({
             role: "user",
@@ -112,7 +106,7 @@ export class GPT {
                 }
             ]
         });
-        
+
         return this.sendRequest(imageMessages, systemMessage);
     }
 

--- a/src/models/gpt.js
+++ b/src/models/gpt.js
@@ -9,8 +9,10 @@ export function normalizeApiKeyAlias(apiKeyAlias) {
         throw new Error('api_key_alias must be a string.');
 
     const alias = apiKeyAlias.trim();
-    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(alias))
-        throw new Error('api_key_alias must be a valid environment/key identifier.');
+    if (alias.length === 0)
+        return 'OPENAI_API_KEY';
+    if (/[\r\n\0]/.test(alias))
+        throw new Error('api_key_alias must not contain control characters.');
     return alias;
 }
 

--- a/src/models/gpt.js
+++ b/src/models/gpt.js
@@ -35,8 +35,14 @@ export class GPT {
     }
 
     async sendRequest(turns, systemMessage, stop_seq='***') {
-        const model = this.model_name || "gpt-5.4-mini";
-        let res;
+        let messages = strictFormat(turns);
+        messages = messages.map(message => {
+            message.content += stop_seq;
+            return message;
+        });
+        let model = this.model_name || "gpt-5.4-mini";
+
+        let res = null;
 
         try {
             console.log('Awaiting openai api response from model', model);
@@ -54,12 +60,12 @@ export class GPT {
                 if (model.includes('o1') || model.includes('o3') || model.includes('5')) {
                     delete pack.stop;
                 }
-                const completion = await this.openai.chat.completions.create(pack);
+                let completion = await this.openai.chat.completions.create(pack);
                 if (completion.choices[0].finish_reason == 'length')
-                    throw new Error('Context length exceeded');
+                    throw new Error('Context length exceeded'); 
                 console.log('Received.');
                 res = completion.choices[0].message.content;
-            }
+            } 
             // otherwise, use responses
             else {
                 let messages = strictFormat(turns);
@@ -75,7 +81,7 @@ export class GPT {
                 });
                 console.log('Received.');
                 res = response.output_text;
-                const stop_seq_index = res.indexOf(stop_seq);
+                let stop_seq_index = res.indexOf(stop_seq);
                 res = stop_seq_index !== -1 ? res.slice(0, stop_seq_index) : res;
             }
         }
@@ -94,7 +100,7 @@ export class GPT {
         return res;
     }
 
-    sendVisionRequest(messages, systemMessage, imageBuffer) {
+    async sendVisionRequest(messages, systemMessage, imageBuffer) {
         const imageMessages = [...messages];
         imageMessages.push({
             role: "user",
@@ -106,7 +112,7 @@ export class GPT {
                 }
             ]
         });
-
+        
         return this.sendRequest(imageMessages, systemMessage);
     }
 
@@ -128,7 +134,7 @@ const sendAudioRequest = async (text, model, voice, url) => {
         model: model,
         voice: voice,
         input: text
-    };
+    }
 
     let config = {};
 
@@ -146,9 +152,9 @@ const sendAudioRequest = async (text, model, voice, url) => {
     const buffer = Buffer.from(await mp3.arrayBuffer());
     const base64 = buffer.toString("base64");
     return base64;
-};
+}
 
 export const TTSConfig = {
     sendAudioRequest: sendAudioRequest,
     baseUrl: 'https://api.openai.com/v1',
-};
+}

--- a/src/models/gpt.js
+++ b/src/models/gpt.js
@@ -134,7 +134,7 @@ const sendAudioRequest = async (text, model, voice, url) => {
         model: model,
         voice: voice,
         input: text
-    }
+    };
 
     let config = {};
 
@@ -152,9 +152,9 @@ const sendAudioRequest = async (text, model, voice, url) => {
     const buffer = Buffer.from(await mp3.arrayBuffer());
     const base64 = buffer.toString("base64");
     return base64;
-}
+};
 
 export const TTSConfig = {
     sendAudioRequest: sendAudioRequest,
     baseUrl: 'https://api.openai.com/v1',
-}
+};

--- a/src/models/gpt.js
+++ b/src/models/gpt.js
@@ -4,10 +4,11 @@ import { strictFormat } from '../utils/text.js';
 
 export class GPT {
     static prefix = 'openai';
-    constructor(model_name, url, params) {
+    constructor(model_name, url, params, api_key_alias=null) {
         this.model_name = model_name;
         this.params = params;
         this.url = url; // store so that we know whether a custom URL has been set
+        this.api_key_alias = api_key_alias || 'OPENAI_API_KEY';
 
         let config = {};
         if (url)
@@ -16,7 +17,7 @@ export class GPT {
         if (hasKey('OPENAI_ORG_ID'))
             config.organization = getKey('OPENAI_ORG_ID');
 
-        config.apiKey = getKey('OPENAI_API_KEY');
+        config.apiKey = getKey(this.api_key_alias);
 
         this.openai = new OpenAIApi(config);
     }

--- a/src/models/gpt.js
+++ b/src/models/gpt.js
@@ -2,13 +2,25 @@ import OpenAIApi from 'openai';
 import { getKey, hasKey } from '../utils/keys.js';
 import { strictFormat } from '../utils/text.js';
 
+export function normalizeApiKeyAlias(apiKeyAlias) {
+    if (apiKeyAlias == null || apiKeyAlias === '')
+        return 'OPENAI_API_KEY';
+    if (typeof apiKeyAlias !== 'string')
+        throw new Error('api_key_alias must be a string.');
+
+    const alias = apiKeyAlias.trim();
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(alias))
+        throw new Error('api_key_alias must be a valid environment/key identifier.');
+    return alias;
+}
+
 export class GPT {
     static prefix = 'openai';
     constructor(model_name, url, params, api_key_alias=null) {
         this.model_name = model_name;
         this.params = params;
         this.url = url; // store so that we know whether a custom URL has been set
-        this.api_key_alias = api_key_alias || 'OPENAI_API_KEY';
+        this.api_key_alias = normalizeApiKeyAlias(api_key_alias);
 
         let config = {};
         if (url)

--- a/tests/openai_api_key_alias.test.js
+++ b/tests/openai_api_key_alias.test.js
@@ -1,0 +1,14 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { normalizeApiKeyAlias } from '../src/models/gpt.js';
+
+test('API key alias defaults and normalizes environment-style identifiers', () => {
+    assert.equal(normalizeApiKeyAlias(), 'OPENAI_API_KEY');
+    assert.equal(normalizeApiKeyAlias('  LOCAL_LLM_KEY  '), 'LOCAL_LLM_KEY');
+});
+
+test('API key alias rejects invalid profile values', () => {
+    assert.throws(() => normalizeApiKeyAlias(123), /must be a string/);
+    assert.throws(() => normalizeApiKeyAlias('bad-key'), /valid environment\/key identifier/);
+    assert.throws(() => normalizeApiKeyAlias('1BAD'), /valid environment\/key identifier/);
+});

--- a/tests/openai_api_key_alias.test.js
+++ b/tests/openai_api_key_alias.test.js
@@ -2,13 +2,16 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { normalizeApiKeyAlias } from '../src/models/gpt.js';
 
-test('API key alias defaults and normalizes environment-style identifiers', () => {
+test('API key alias defaults and normalizes configured identifiers', () => {
     assert.equal(normalizeApiKeyAlias(), 'OPENAI_API_KEY');
+    assert.equal(normalizeApiKeyAlias(''), 'OPENAI_API_KEY');
+    assert.equal(normalizeApiKeyAlias('   '), 'OPENAI_API_KEY');
     assert.equal(normalizeApiKeyAlias('  LOCAL_LLM_KEY  '), 'LOCAL_LLM_KEY');
+    assert.equal(normalizeApiKeyAlias('local-openai'), 'local-openai');
 });
 
-test('API key alias rejects invalid profile values', () => {
+test('API key alias rejects non-string and control-character values', () => {
     assert.throws(() => normalizeApiKeyAlias(123), /must be a string/);
-    assert.throws(() => normalizeApiKeyAlias('bad-key'), /valid environment\/key identifier/);
-    assert.throws(() => normalizeApiKeyAlias('1BAD'), /valid environment\/key identifier/);
+    assert.throws(() => normalizeApiKeyAlias('bad\nkey'), /control characters/);
+    assert.throws(() => normalizeApiKeyAlias('bad\0key'), /control characters/);
 });


### PR DESCRIPTION
## Merge status

**BLOCKED BY:** None

This PR has no known dependency on another PR in the #59-#90 series.

## Summary
Allow OpenAI-compatible model profiles to select a named API-key alias instead of always reading `OPENAI_API_KEY`.

## Why
Mindcraft can target multiple local or remote OpenAI-compatible endpoints. Requiring all of them to share one key makes multi-provider and multi-endpoint setups awkward.

## Changes
- Pass `api_key_alias` through model construction.
- Default to `OPENAI_API_KEY` for backwards compatibility.
- Resolve the selected alias through the existing key helper.

## Compatibility
Existing profiles without `api_key_alias` continue to behave as before.