### PR TITLE
Normalize placeable block item aliases in placeHere

### DIFF
--- a/src/agent/commands/index.js
+++ b/src/agent/commands/index.js
@@ -139,6 +139,7 @@ export function parseCommandMessage(message) {
             case 'ItemName':
                 if (arg.endsWith('plank') || arg.endsWith('seed'))
                     arg += 's'; // add 's' to for common mistakes like "oak_plank" or "wheat_seed"
+                break;
             case 'string':
                 break;
             default:

--- a/src/agent/commands/index.js
+++ b/src/agent/commands/index.js
@@ -1,6 +1,7 @@
 import { getBlockId, getItemId } from "../../utils/mcdata.js";
 import { actionsList } from './actions.js';
 import { queryList } from './queries.js';
+import { normalizePlacementItemName } from './placement_aliases.js';
 
 let suppressNoDomainWarning = true;
 
@@ -28,15 +29,6 @@ export function blacklistCommands(commands) {
 
 const commandRegex = /!(\w+)(?:\(((?:-?\d+(?:\.\d+)?|true|false|"[^"]*")(?:\s*,\s*(?:-?\d+(?:\.\d+)?|true|false|"[^"]*"))*)\))?/
 const argRegex = /-?\d+(?:\.\d+)?|true|false|"[^"]*"/g;
-
-// Some placeable blocks use a differently named inventory item.
-// Normalize these only for !placeHere so other block/item commands keep their
-// existing semantics.
-const placementItemAliases = {
-    tripwire: 'string',
-    potatoes: 'potato',
-    wheat: 'wheat_seeds',
-};
 
 export function containsCommand(message) {
     const commandMatch = message.match(commandRegex);
@@ -132,7 +124,7 @@ export function parseCommandMessage(message) {
         }
 
         if (commandName === '!placeHere' && param.type === 'BlockOrItemName')
-            arg = placementItemAliases[arg] ?? arg;
+            arg = normalizePlacementItemName(arg);
         
         //Convert to the correct type
         switch(param.type) {

--- a/src/agent/commands/index.js
+++ b/src/agent/commands/index.js
@@ -29,6 +29,15 @@ export function blacklistCommands(commands) {
 const commandRegex = /!(\w+)(?:\(((?:-?\d+(?:\.\d+)?|true|false|"[^"]*")(?:\s*,\s*(?:-?\d+(?:\.\d+)?|true|false|"[^"]*"))*)\))?/
 const argRegex = /-?\d+(?:\.\d+)?|true|false|"[^"]*"/g;
 
+// Some placeable blocks use a differently named inventory item.
+// Normalize these only for !placeHere so other block/item commands keep their
+// existing semantics.
+const placementItemAliases = {
+    tripwire: 'string',
+    potatoes: 'potato',
+    wheat: 'wheat_seeds',
+};
+
 export function containsCommand(message) {
     const commandMatch = message.match(commandRegex);
     if (commandMatch)
@@ -121,6 +130,9 @@ export function parseCommandMessage(message) {
         if ((arg.startsWith('"') && arg.endsWith('"')) || (arg.startsWith("'") && arg.endsWith("'"))) {
             arg = arg.substring(1, arg.length-1);
         }
+
+        if (commandName === '!placeHere' && param.type === 'BlockOrItemName')
+            arg = placementItemAliases[arg] ?? arg;
         
         //Convert to the correct type
         switch(param.type) {

--- a/src/agent/commands/index.js
+++ b/src/agent/commands/index.js
@@ -27,7 +27,7 @@ export function blacklistCommands(commands) {
     }
 }
 
-const commandRegex = /!(\w+)(?:\(((?:-?\d+(?:\.\d+)?|true|false|"[^"]*")(?:\s*,\s*(?:-?\d+(?:\.\d+)?|true|false|"[^"]*"))*)\))?/
+const commandRegex = /!(\w+)(?:\(((?:-?\d+(?:\.\d+)?|true|false|"[^"]*")(?:\s*,\s*(?:-?\d+(?:\.\d+)?|true|false|"[^"]*"))*)\))?/;
 const argRegex = /-?\d+(?:\.\d+)?|true|false|"[^"]*"/g;
 
 export function containsCommand(message) {
@@ -82,7 +82,7 @@ function checkInInterval(number, lowerBound, upperBound, endpointType) {
         case '[]':
             return lowerBound <= number && number <= upperBound;
         default:
-            throw new Error('Unknown endpoint type:', endpointType)
+            throw new Error('Unknown endpoint type:', endpointType);
     }
 }
 
@@ -106,7 +106,7 @@ export function parseCommandMessage(message) {
     else args = [];
 
     const command = getCommand(commandName);
-    if(!command) return `${commandName} is not a command.`
+    if(!command) return `${commandName} is not a command.`;
 
     const params = commandParams(command);
     const paramNames = commandParamNames(command);
@@ -145,7 +145,7 @@ export function parseCommandMessage(message) {
                 throw new Error(`Command '${commandName}' parameter '${paramNames[i]}' has an unknown type: ${param.type}`);
         }
         if(arg === null || Number.isNaN(arg))
-            return `Error: Param '${paramNames[i]}' must be of type ${param.type}.`
+            return `Error: Param '${paramNames[i]}' must be of type ${param.type}.`;
 
         if(typeof arg === 'number') { //Check the domain of numbers
             const domain = param.domain;
@@ -161,15 +161,15 @@ export function parseCommandMessage(message) {
                     //Alternatively arg could be set to the nearest value in the domain.
                 }
             } else if (!suppressNoDomainWarning) {
-                console.warn(`Command '${commandName}' parameter '${paramNames[i]}' has no domain set. Expect any value [-Infinity, Infinity].`)
+                console.warn(`Command '${commandName}' parameter '${paramNames[i]}' has no domain set. Expect any value [-Infinity, Infinity].`);
                 suppressNoDomainWarning = true; //Don't spam console. Only give the warning once.
             }
         } else if(param.type === 'BlockName') { //Check that there is a block with this name
-            if(getBlockId(arg) == null) return  `Invalid block type: ${arg}.`
+            if(getBlockId(arg) == null) return  `Invalid block type: ${arg}.`;
         } else if(param.type === 'ItemName') { //Check that there is an item with this name
-            if(getItemId(arg) == null) return `Invalid item type: ${arg}.`
+            if(getItemId(arg) == null) return `Invalid item type: ${arg}.`;
         } else if(param.type === 'BlockOrItemName') {
-            if(getBlockId(arg) == null && getItemId(arg) == null) return  `Invalid block or item type: ${arg}.`
+            if(getBlockId(arg) == null && getItemId(arg) == null) return  `Invalid block or item type: ${arg}.`;
         }
         args[i] = arg;
     }
@@ -243,7 +243,7 @@ export function getCommandDocs(agent) {
         'ItemName':          'string',
         'BlockOrItemName':   'string',
         'boolean':           'bool'
-    }
+    };
     let docs = `\n*COMMAND DOCS\n You can use the following commands to perform actions and get information about the world. 
     Use the commands with the syntax: !commandName or !commandName("arg1", 1.2, ...) if the command takes arguments.\n
     Do not use codeblocks. Use double quotes for strings. Only use one command in each response, trailing commands and comments will be ignored.\n`;

--- a/src/agent/commands/placement_aliases.js
+++ b/src/agent/commands/placement_aliases.js
@@ -1,0 +1,9 @@
+const PLACEMENT_ITEM_ALIASES = Object.freeze({
+    tripwire: 'string',
+    potatoes: 'potato',
+    wheat: 'wheat_seeds',
+});
+
+export function normalizePlacementItemName(name) {
+    return PLACEMENT_ITEM_ALIASES[name] ?? name;
+}

--- a/tests/placement_aliases.test.js
+++ b/tests/placement_aliases.test.js
@@ -1,0 +1,13 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { normalizePlacementItemName } from '../src/agent/commands/placement_aliases.js';
+
+test('placeHere aliases normalize block registry names to inventory item names', () => {
+    assert.equal(normalizePlacementItemName('tripwire'), 'string');
+    assert.equal(normalizePlacementItemName('potatoes'), 'potato');
+    assert.equal(normalizePlacementItemName('wheat'), 'wheat_seeds');
+});
+
+test('unknown placement names pass through unchanged', () => {
+    assert.equal(normalizePlacementItemName('oak_planks'), 'oak_planks');
+});


### PR DESCRIPTION
## Merge status

**BLOCKED BY:** None

This PR has no known dependency on another PR in the #59-#90 series.

## Summary
Normalize a small set of Minecraft block names to their corresponding inventory item names when parsing `!placeHere`.

## Why
Some placeable blocks use a different registry name in inventory. A model can correctly identify the desired block but still fail validation because the held item uses another name.

## Changes
- Add targeted aliases for affected placeable items.
- Apply aliases only to `!placeHere`.
- Preserve existing parsing semantics for other commands.

## Scope
Command argument normalization only.