### PR TITLE
Fix recursive SES lockdown wrapper

### DIFF
--- a/src/agent/library/lockdown.js
+++ b/src/agent/library/lockdown.js
@@ -8,8 +8,10 @@ import 'ses';
 let lockeddown = false;
 export function lockdown() {
   if (lockeddown) return;
-  lockeddown = true;
-  lockdown({
+
+  // `ses` installs lockdown on globalThis. Call it explicitly here so this
+  // wrapper does not recursively call itself.
+  globalThis.lockdown({
     // basic devex and quality of life improvements
     localeTaming: 'unsafe',
     consoleTaming: 'unsafe',
@@ -19,6 +21,8 @@ export function lockdown() {
     // (mineflayer dep "protodef" uses eval)
     evalTaming: 'unsafeEval',
   });
+
+  lockeddown = true;
 }
 
 export const makeCompartment = (endowments = {}) => {
@@ -29,4 +33,4 @@ export const makeCompartment = (endowments = {}) => {
     // standard endowments
     ...endowments
   });
-}
+};

--- a/src/agent/library/lockdown.js
+++ b/src/agent/library/lockdown.js
@@ -26,7 +26,7 @@ export function lockdown() {
 }
 
 export const makeCompartment = (endowments = {}) => {
-  return new Compartment({
+  return new globalThis.Compartment({
     // provide untamed Math, Date, etc
     Math,
     Date,

--- a/tests/lockdown.test.js
+++ b/tests/lockdown.test.js
@@ -1,0 +1,9 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { lockdown as secureLockdown } from '../src/agent/library/lockdown.js';
+
+test('SES lockdown wrapper invokes the SES global and is idempotent', () => {
+    assert.equal(typeof globalThis.lockdown, 'function');
+    assert.doesNotThrow(() => secureLockdown());
+    assert.doesNotThrow(() => secureLockdown());
+});


### PR DESCRIPTION
## Merge status

**BLOCKED BY:** None

This PR has no known dependency on another PR in the #59-#90 series.

## Summary
Fix the SES lockdown wrapper so it calls the global SES `lockdown()` implementation rather than recursively invoking itself.

## Why
The local wrapper shadows the SES global function name, so calling `lockdown()` from inside the wrapper recurses instead of initializing SES.

## Changes
- Call `globalThis.lockdown(...)` explicitly.
- Mark lockdown complete only after the SES call succeeds.
- Add a regression test covering idempotent repeated calls.

## Scope
Generated-code sandbox initialization only.