### PR TITLE
Reset action timeout state and preserve thrown error diagnostics

### DIFF
--- a/src/agent/action_manager.js
+++ b/src/agent/action_manager.js
@@ -13,11 +13,11 @@ export class ActionManager {
         this.recent_action_counter = 0;
     }
 
-    async resumeAction(timeout) {
+    resumeAction(timeout) {
         return this._executeResume(null, null, timeout);
     }
 
-    async runAction(actionLabel, actionFn, { timeout, resume = false } = {}) {
+    runAction(actionLabel, actionFn, { timeout, resume = false } = {}) {
         if (resume) {
             return this._executeResume(actionLabel, actionFn, timeout);
         } else {

--- a/src/agent/action_manager.js
+++ b/src/agent/action_manager.js
@@ -1,3 +1,5 @@
+import assert from 'node:assert/strict';
+
 export class ActionManager {
     constructor(agent) {
         this.agent = agent;
@@ -11,8 +13,8 @@ export class ActionManager {
         this.recent_action_counter = 0;
     }
 
-    async resumeAction(actionFn, timeout) {
-        return this._executeResume(actionFn, timeout);
+    async resumeAction(timeout) {
+        return this._executeResume(null, null, timeout);
     }
 
     async runAction(actionLabel, actionFn, { timeout, resume = false } = {}) {
@@ -34,7 +36,7 @@ export class ActionManager {
             await new Promise(resolve => setTimeout(resolve, 300));
         }
         clearTimeout(timeout);
-    } 
+    }
 
     cancelResume() {
         this.resume_func = null;
@@ -60,6 +62,7 @@ export class ActionManager {
 
     async _executeAction(actionLabel, actionFn, timeout = 10) {
         let TIMEOUT;
+        this.timedout = false;
         try {
             if (this.last_action_time > 0) {
                 let time_diff = Date.now() - this.last_action_time;
@@ -129,23 +132,24 @@ export class ActionManager {
             this.currentActionFn = null;
             clearTimeout(TIMEOUT);
             this.cancelResume();
-            console.error("Code execution triggered catch:", err);
-            // Log the full stack trace
-            console.error(err.stack);
+            console.error('Code execution triggered catch:', err);
+            console.error(err?.stack);
             await this.stop();
-            err = err.toString();
 
+            const errString = err instanceof Error ? err.toString() : String(err);
+            const stack = err instanceof Error && err.stack ? err.stack : '';
             let message = this.getBotOutputSummary() +
                 '!!Code threw exception!!\n' +
-                'Error: ' + err + '\n' +
-                'Stack trace:\n' + err.stack+'\n';
+                'Error: ' + errString + '\n' +
+                'Stack trace:\n' + stack + '\n';
 
             let interrupted = this.agent.bot.interrupt_code;
+            let timedout = this.timedout;
             this.agent.clearBotLogs();
             if (!interrupted) {
                 this.agent.bot.emit('idle');
             }
-            return { success: false, message, interrupted, timedout: false };
+            return { success: false, message, interrupted, timedout };
         }
     }
 

--- a/tests/action_manager.test.js
+++ b/tests/action_manager.test.js
@@ -61,7 +61,7 @@ test('resumeAction reuses the stored resumable action', async () => {
 
     const first = await actions.runAction(
         'repeatable',
-        async () => { calls++; },
+        () => { calls++; },
         { timeout: -1, resume: true }
     );
     const resumed = await actions.resumeAction(-1);

--- a/tests/action_manager.test.js
+++ b/tests/action_manager.test.js
@@ -30,7 +30,7 @@ test('a previous timeout does not leak into the next action result', async () =>
     agent.actions = actions;
     actions.timedout = true;
 
-    const result = await actions.runAction('test', async () => {}, { timeout: -1 });
+    const result = await actions.runAction('test', () => Promise.resolve(), { timeout: -1 });
 
     assert.equal(result.success, true);
     assert.equal(result.timedout, false);

--- a/tests/action_manager.test.js
+++ b/tests/action_manager.test.js
@@ -1,0 +1,52 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import { ActionManager } from '../src/agent/action_manager.js';
+
+function makeAgent() {
+    const bot = new EventEmitter();
+    bot.output = '';
+    bot.interrupt_code = false;
+
+    return {
+        bot,
+        self_prompter: { isActive: () => false },
+        history: { add: () => {} },
+        isIdle() { return !this.actions?.executing; },
+        clearBotLogs() {
+            bot.output = '';
+            bot.interrupt_code = false;
+        },
+        requestInterrupt() {
+            bot.interrupt_code = true;
+        },
+        cleanKill() {}
+    };
+}
+
+test('a previous timeout does not leak into the next action result', async () => {
+    const agent = makeAgent();
+    const actions = new ActionManager(agent);
+    agent.actions = actions;
+    actions.timedout = true;
+
+    const result = await actions.runAction('test', async () => {}, { timeout: -1 });
+
+    assert.equal(result.success, true);
+    assert.equal(result.timedout, false);
+});
+
+test('thrown action errors preserve their stack trace', async () => {
+    const agent = makeAgent();
+    const actions = new ActionManager(agent);
+    agent.actions = actions;
+
+    const result = await actions.runAction('throwing', async () => {
+        throw new Error('boom');
+    }, { timeout: -1 });
+
+    assert.equal(result.success, false);
+    assert.match(result.message, /Error: boom/);
+    assert.match(result.message, /Stack trace:/);
+    assert.doesNotMatch(result.message, /Stack trace:\nundefined/);
+});

--- a/tests/action_manager.test.js
+++ b/tests/action_manager.test.js
@@ -52,3 +52,21 @@ test('thrown action errors preserve their stack trace', async () => {
     assert.match(result.message, /Stack trace:/);
     assert.doesNotMatch(result.message, /Stack trace:\nundefined/);
 });
+
+test('resumeAction reuses the stored resumable action', async () => {
+    const agent = makeAgent();
+    const actions = new ActionManager(agent);
+    agent.actions = actions;
+    let calls = 0;
+
+    const first = await actions.runAction(
+        'repeatable',
+        async () => { calls++; },
+        { timeout: -1, resume: true }
+    );
+    const resumed = await actions.resumeAction(-1);
+
+    assert.equal(first.success, true);
+    assert.equal(resumed.success, true);
+    assert.equal(calls, 2);
+});

--- a/tests/action_manager.test.js
+++ b/tests/action_manager.test.js
@@ -41,9 +41,11 @@ test('thrown action errors preserve their stack trace', async () => {
     const actions = new ActionManager(agent);
     agent.actions = actions;
 
-    const result = await actions.runAction('throwing', async () => {
-        throw new Error('boom');
-    }, { timeout: -1 });
+    const result = await actions.runAction(
+        'throwing',
+        () => Promise.reject(new Error('boom')),
+        { timeout: -1 }
+    );
 
     assert.equal(result.success, false);
     assert.match(result.message, /Error: boom/);


### PR DESCRIPTION
## Merge status

**BLOCKED BY:** None

This PR has no known dependency on another PR in the #59-#90 series.

## Summary
Tighten `ActionManager` state handling between actions and preserve useful error diagnostics when an action throws.

## Why
A timeout flag from a previous action can leak into a later action result, and thrown errors can lose their stack trace in the returned action summary.

## Changes
- Reset timeout state at the start of each action.
- Preserve thrown error text and stack traces.
- Add regression coverage for timeout-state leakage and thrown errors.

## Scope
Action bookkeeping and diagnostics only.