### PR TITLE
Remove blacklisted commands from the active command registry

### DIFF
--- a/src/agent/commands/index.js
+++ b/src/agent/commands/index.js
@@ -139,6 +139,7 @@ export function parseCommandMessage(message) {
             case 'ItemName':
                 if (arg.endsWith('plank') || arg.endsWith('seed'))
                     arg += 's'; // add 's' to for common mistakes like "oak_plank" or "wheat_seed"
+                break;
             case 'string':
                 break;
             default:

--- a/src/agent/commands/index.js
+++ b/src/agent/commands/index.js
@@ -30,7 +30,7 @@ export function blacklistCommands(commands) {
     }
 }
 
-const commandRegex = /!(\w+)(?:\(((?:-?\d+(?:\.\d+)?|true|false|"[^"]*")(?:\s*,\s*(?:-?\d+(?:\.\d+)?|true|false|"[^"]*"))*)\))?/
+const commandRegex = /!(\w+)(?:\(((?:-?\d+(?:\.\d+)?|true|false|"[^"]*")(?:\s*,\s*(?:-?\d+(?:\.\d+)?|true|false|"[^"]*"))*)\))?/;
 const argRegex = /-?\d+(?:\.\d+)?|true|false|"[^"]*"/g;
 
 export function containsCommand(message) {
@@ -85,7 +85,7 @@ function checkInInterval(number, lowerBound, upperBound, endpointType) {
         case '[]':
             return lowerBound <= number && number <= upperBound;
         default:
-            throw new Error('Unknown endpoint type:', endpointType)
+            throw new Error('Unknown endpoint type:', endpointType);
     }
 }
 
@@ -109,7 +109,7 @@ export function parseCommandMessage(message) {
     else args = [];
 
     const command = getCommand(commandName);
-    if(!command) return `${commandName} is not a command.`
+    if(!command) return `${commandName} is not a command.`;
 
     const params = commandParams(command);
     const paramNames = commandParamNames(command);
@@ -145,7 +145,7 @@ export function parseCommandMessage(message) {
                 throw new Error(`Command '${commandName}' parameter '${paramNames[i]}' has an unknown type: ${param.type}`);
         }
         if(arg === null || Number.isNaN(arg))
-            return `Error: Param '${paramNames[i]}' must be of type ${param.type}.`
+            return `Error: Param '${paramNames[i]}' must be of type ${param.type}.`;
 
         if(typeof arg === 'number') { //Check the domain of numbers
             const domain = param.domain;
@@ -161,15 +161,15 @@ export function parseCommandMessage(message) {
                     //Alternatively arg could be set to the nearest value in the domain.
                 }
             } else if (!suppressNoDomainWarning) {
-                console.warn(`Command '${commandName}' parameter '${paramNames[i]}' has no domain set. Expect any value [-Infinity, Infinity].`)
+                console.warn(`Command '${commandName}' parameter '${paramNames[i]}' has no domain set. Expect any value [-Infinity, Infinity].`);
                 suppressNoDomainWarning = true; //Don't spam console. Only give the warning once.
             }
         } else if(param.type === 'BlockName') { //Check that there is a block with this name
-            if(getBlockId(arg) == null) return  `Invalid block type: ${arg}.`
+            if(getBlockId(arg) == null) return  `Invalid block type: ${arg}.`;
         } else if(param.type === 'ItemName') { //Check that there is an item with this name
-            if(getItemId(arg) == null) return `Invalid item type: ${arg}.`
+            if(getItemId(arg) == null) return `Invalid item type: ${arg}.`;
         } else if(param.type === 'BlockOrItemName') {
-            if(getBlockId(arg) == null && getItemId(arg) == null) return  `Invalid block or item type: ${arg}.`
+            if(getBlockId(arg) == null && getItemId(arg) == null) return  `Invalid block or item type: ${arg}.`;
         }
         args[i] = arg;
     }
@@ -243,7 +243,7 @@ export function getCommandDocs(agent) {
         'ItemName':          'string',
         'BlockOrItemName':   'string',
         'boolean':           'bool'
-    }
+    };
     let docs = `\n*COMMAND DOCS\n You can use the following commands to perform actions and get information about the world. 
     Use the commands with the syntax: !commandName or !commandName("arg1", 1.2, ...) if the command takes arguments.\n
     Do not use codeblocks. Use double quotes for strings. Only use one command in each response, trailing commands and comments will be ignored.\n`;

--- a/src/agent/commands/index.js
+++ b/src/agent/commands/index.js
@@ -21,8 +21,12 @@ export function blacklistCommands(commands) {
             console.warn(`Command ${command_name} is unblockable`);
             continue;
         }
+
         delete commandMap[command_name];
-        delete commandList.find(command => command.name === command_name);
+        const index = commandList.findIndex(command => command.name === command_name);
+        if (index !== -1) {
+            commandList.splice(index, 1);
+        }
     }
 }
 

--- a/tests/command_blacklist.test.js
+++ b/tests/command_blacklist.test.js
@@ -1,0 +1,12 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { blacklistCommands, commandExists, getCommandDocs } from '../src/agent/commands/index.js';
+
+test('blacklisting removes a command from lookup and generated docs', () => {
+    assert.equal(commandExists('!nearbyBlocks'), true);
+    blacklistCommands(['!nearbyBlocks']);
+    assert.equal(commandExists('!nearbyBlocks'), false);
+
+    const docs = getCommandDocs({ blocked_actions: [] });
+    assert.doesNotMatch(docs, /!nearbyBlocks/);
+});


### PR DESCRIPTION
## Merge status

**BLOCKED BY:** None

This PR has no known dependency on another PR in the #59-#90 series.

## Summary
Make command blacklisting remove commands from both lookup and the generated command list/docs.

## Why
Deleting a property from the command map is not enough if the command remains in the command list. The model can still be shown a supposedly blocked command.

## Changes
- Remove blacklisted commands from the map.
- Remove the matching command from the command list.
- Add a regression test verifying lookup and docs both exclude the command.

## Scope
Command registry consistency only.