### PR TITLE
Harden multi-agent conversation timer and queue lifecycle

### DIFF
--- a/src/agent/conversation.js
+++ b/src/agent/conversation.js
@@ -6,7 +6,13 @@ let agent;
 let agent_names = [];
 let agents_in_game = [];
 
-class Conversation {
+function runDetached(operation, context) {
+    Promise.resolve(operation).catch(error => {
+        console.error(`${context}:`, error);
+    });
+}
+
+export class Conversation {
     constructor(name) {
         this.name = name;
         this.active = false;
@@ -34,9 +40,13 @@ class Conversation {
         this.clearTimer();
         this.active = false;
         this.ignore_until_start = true;
-        const full_message = _compileInMessages(this);
-        if (full_message.message.trim().length > 0)
-            void agent.history.add(this.name, full_message.message);
+        const full_message = compileInMessages(this);
+        if (full_message.message.trim().length > 0) {
+            runDetached(
+                agent.history.add(this.name, full_message.message),
+                `Failed to archive queued conversation with ${this.name}`
+            );
+        }
         // add the full queued messages to history, but don't respond
 
         if (agent.last_sender === this.name)
@@ -85,7 +95,10 @@ class ConversationManager {
             if (this.awaiting_response && agent.isIdle()) {
                 wait_time += delta;
                 if (wait_time > this.wait_time_limit) {
-                    void agent.handleMessage('system', `${convo_partner} hasn't responded in ${this.wait_time_limit/1000} seconds, respond with a message to them or your own action.`);
+                    runDetached(
+                        agent.handleMessage('system', `${convo_partner} hasn't responded in ${this.wait_time_limit/1000} seconds, respond with a message to them or your own action.`),
+                        `Failed to prompt for stalled conversation with ${convo_partner}`
+                    );
                     wait_time = 0;
                     this.wait_time_limit*=2;
                 }
@@ -103,7 +116,10 @@ class ConversationManager {
                     }
                     if (!agent.self_prompter.isPaused()) {
                         this.endConversation(convo_partner);
-                        void agent.handleMessage('system', `${convo_partner} disconnected, conversation has ended.`);
+                        runDetached(
+                            agent.handleMessage('system', `${convo_partner} disconnected, conversation has ended.`),
+                            `Failed to report disconnected conversation partner ${convo_partner}`
+                        );
                     }
                     else {
                         this.endConversation(convo_partner);
@@ -155,7 +171,7 @@ class ConversationManager {
         const convo = this._getConvo(send_to);
 
         if (settings.chat_bot_messages && open_chat)
-            agent.openChat(`(To ${send_to}) ${message}`);
+            runDetached(agent.openChat(`(To ${send_to}) ${message}`), `Failed to mirror message to ${send_to}`);
 
         if (convo.ignore_until_start)
             return;
@@ -241,7 +257,7 @@ class ConversationManager {
             this._stopMonitor();
             this.activeConversation = null;
             if (agent.self_prompter.isPaused() && !this.inConversation()) {
-                void _resumeSelfPrompter();
+                runDetached(_resumeSelfPrompter(), 'Failed to resume self-prompting after conversation end');
             }
         }
     }
@@ -251,7 +267,7 @@ class ConversationManager {
             this.endConversation(sender);
         }
         if (agent.self_prompter.isPaused()) {
-            void _resumeSelfPrompter();
+            runDetached(_resumeSelfPrompter(), 'Failed to resume self-prompting after ending conversations');
         }
     }
 
@@ -319,10 +335,10 @@ async function _scheduleProcessInMessage(sender, received, convo) {
 function _processInMessageQueue(name) {
     const convo = convoManager._getConvo(name);
     convo.inMessageTimer = null;
-    _handleFullInMessage(name, _compileInMessages(convo));
+    _handleFullInMessage(name, compileInMessages(convo));
 }
 
-function _compileInMessages(convo) {
+export function compileInMessages(convo) {
     let pack = {};
     const messages = [];
     while (convo.in_queue.length > 0) {
@@ -348,7 +364,7 @@ function _handleFullInMessage(sender, received) {
     else if (received.start)
         agent.shut_up = false;
     convo.inMessageTimer = null;
-    void agent.handleMessage(sender, message);
+    runDetached(agent.handleMessage(sender, message), `Failed to handle queued conversation message from ${sender}`);
 }
 
 function _tagMessage(message) {

--- a/src/agent/conversation.js
+++ b/src/agent/conversation.js
@@ -16,17 +16,24 @@ class Conversation {
         this.inMessageTimer = null;
     }
 
+    clearTimer() {
+        if (this.inMessageTimer) {
+            clearTimeout(this.inMessageTimer);
+            this.inMessageTimer = null;
+        }
+    }
+
     reset() {
+        this.clearTimer();
         this.active = false;
         this.ignore_until_start = false;
         this.in_queue = [];
-        this.inMessageTimer = null;
     }
 
     end() {
+        this.clearTimer();
         this.active = false;
         this.ignore_until_start = true;
-        this.inMessageTimer = null;
         const full_message = _compileInMessages(this);
         if (full_message.message.trim().length > 0)
             agent.history.add(this.name, full_message.message);
@@ -121,7 +128,7 @@ class ConversationManager {
     async startConversation(send_to, message) {
         const convo = this._getConvo(send_to);
         convo.reset();
-        
+
         if (agent.self_prompter.isActive()) {
             await agent.self_prompter.pause();
         }
@@ -146,14 +153,14 @@ class ConversationManager {
             return;
         }
         const convo = this._getConvo(send_to);
-        
+
         if (settings.chat_bot_messages && open_chat)
             agent.openChat(`(To ${send_to}) ${message}`);
-        
+
         if (convo.ignore_until_start)
             return;
         convo.active = true;
-        
+
         const end = message.includes('!endConversation');
         const json = {
             'message': message,
@@ -185,12 +192,12 @@ class ConversationManager {
 
         this._clearMonitorTimeouts();
         convo.queue(received);
-        
+
         // responding to conversation takes priority over self prompting
         if (agent.self_prompter.isActive()){
             await agent.self_prompter.pause();
         }
-    
+
         _scheduleProcessInMessage(sender, received, convo);
     }
 
@@ -208,7 +215,7 @@ class ConversationManager {
     otherAgentInGame(name) {
         return agents_in_game.some((n) => n === name);
     }
-    
+
     updateAgents(agents) {
         agent_names = agents.map(a => a.name);
         agents_in_game = agents.filter(a => a.in_game).map(a => a.name);
@@ -217,26 +224,28 @@ class ConversationManager {
     getInGameAgents() {
         return agents_in_game;
     }
-    
+
     inConversation(other_agent=null) {
         if (other_agent)
             return this.convos[other_agent]?.active;
         return Object.values(this.convos).some(c => c.active);
     }
-    
+
     endConversation(sender) {
-        if (this.convos[sender]) {
-            this.convos[sender].end();
-            if (this.activeConversation.name === sender) {
-                this._stopMonitor();
-                this.activeConversation = null;
-                if (agent.self_prompter.isPaused() && !this.inConversation()) {
-                    _resumeSelfPrompter();
-                }
+        const convo = this.convos[sender];
+        if (!convo)
+            return;
+
+        convo.end();
+        if (this.activeConversation?.name === sender) {
+            this._stopMonitor();
+            this.activeConversation = null;
+            if (agent.self_prompter.isPaused() && !this.inConversation()) {
+                _resumeSelfPrompter();
             }
         }
     }
-    
+
     endAllConversations() {
         for (const sender in this.convos) {
             this.endConversation(sender);
@@ -271,17 +280,18 @@ const talkOverActions = ['stay', 'followPlayer', 'mode:']; // all mode actions
 const fastDelay = 200;
 const longDelay = 5000;
 async function _scheduleProcessInMessage(sender, received, convo) {
-    if (convo.inMessageTimer)
-        clearTimeout(convo.inMessageTimer);
+    convo.clearTimer();
     let otherAgentBusy = containsCommand(received.message);
 
-    const scheduleResponse = (delay) => convo.inMessageTimer = setTimeout(() => _processInMessageQueue(sender), delay);
+    const scheduleResponse = (delay) => {
+        convo.inMessageTimer = setTimeout(() => _processInMessageQueue(sender), delay);
+    };
 
     if (!agent.isIdle() && otherAgentBusy) {
         // both are busy
         let canTalkOver = talkOverActions.some(a => agent.actions.currentActionLabel.includes(a));
         if (canTalkOver)
-            scheduleResponse(fastDelay)
+            scheduleResponse(fastDelay);
         // otherwise don't respond
     }
     else if (otherAgentBusy)
@@ -308,23 +318,24 @@ async function _scheduleProcessInMessage(sender, received, convo) {
 
 function _processInMessageQueue(name) {
     const convo = convoManager._getConvo(name);
+    convo.inMessageTimer = null;
     _handleFullInMessage(name, _compileInMessages(convo));
 }
 
 function _compileInMessages(convo) {
     let pack = {};
-    let full_message = '';
+    const messages = [];
     while (convo.in_queue.length > 0) {
         pack = convo.in_queue.shift();
-        full_message += pack.message;
+        messages.push(pack.message);
     }
-    pack.message = full_message;
+    pack.message = messages.join('\n');
     return pack;
 }
 
 function _handleFullInMessage(sender, received) {
     console.log(`${agent.name} responding to "${received.message}" from ${sender}`);
-    
+
     const convo = convoManager._getConvo(sender);
     convo.active = true;
 
@@ -340,9 +351,8 @@ function _handleFullInMessage(sender, received) {
     agent.handleMessage(sender, message);
 }
 
-
 function _tagMessage(message) {
-    return "(FROM OTHER BOT)" + message;
+    return "(FROM OTHER BOT)"+message;
 }
 
 async function _resumeSelfPrompter() {

--- a/src/agent/conversation.js
+++ b/src/agent/conversation.js
@@ -36,7 +36,7 @@ class Conversation {
         this.ignore_until_start = true;
         const full_message = _compileInMessages(this);
         if (full_message.message.trim().length > 0)
-            agent.history.add(this.name, full_message.message);
+            void agent.history.add(this.name, full_message.message);
         // add the full queued messages to history, but don't respond
 
         if (agent.last_sender === this.name)
@@ -85,7 +85,7 @@ class ConversationManager {
             if (this.awaiting_response && agent.isIdle()) {
                 wait_time += delta;
                 if (wait_time > this.wait_time_limit) {
-                    agent.handleMessage('system', `${convo_partner} hasn't responded in ${this.wait_time_limit/1000} seconds, respond with a message to them or your own action.`);
+                    void agent.handleMessage('system', `${convo_partner} hasn't responded in ${this.wait_time_limit/1000} seconds, respond with a message to them or your own action.`);
                     wait_time = 0;
                     this.wait_time_limit*=2;
                 }
@@ -103,7 +103,7 @@ class ConversationManager {
                     }
                     if (!agent.self_prompter.isPaused()) {
                         this.endConversation(convo_partner);
-                        agent.handleMessage('system', `${convo_partner} disconnected, conversation has ended.`);
+                        void agent.handleMessage('system', `${convo_partner} disconnected, conversation has ended.`);
                     }
                     else {
                         this.endConversation(convo_partner);
@@ -241,7 +241,7 @@ class ConversationManager {
             this._stopMonitor();
             this.activeConversation = null;
             if (agent.self_prompter.isPaused() && !this.inConversation()) {
-                await _resumeSelfPrompter();
+                void _resumeSelfPrompter();
             }
         }
     }
@@ -251,7 +251,7 @@ class ConversationManager {
             this.endConversation(sender);
         }
         if (agent.self_prompter.isPaused()) {
-            await _resumeSelfPrompter();
+            void _resumeSelfPrompter();
         }
     }
 
@@ -348,7 +348,7 @@ function _handleFullInMessage(sender, received) {
     else if (received.start)
         agent.shut_up = false;
     convo.inMessageTimer = null;
-    agent.handleMessage(sender, message);
+    void agent.handleMessage(sender, message);
 }
 
 function _tagMessage(message) {

--- a/src/agent/conversation.js
+++ b/src/agent/conversation.js
@@ -198,7 +198,7 @@ class ConversationManager {
             await agent.self_prompter.pause();
         }
 
-        _scheduleProcessInMessage(sender, received, convo);
+        await _scheduleProcessInMessage(sender, received, convo);
     }
 
     responseScheduledFor(sender) {
@@ -241,7 +241,7 @@ class ConversationManager {
             this._stopMonitor();
             this.activeConversation = null;
             if (agent.self_prompter.isPaused() && !this.inConversation()) {
-                _resumeSelfPrompter();
+                await _resumeSelfPrompter();
             }
         }
     }
@@ -251,7 +251,7 @@ class ConversationManager {
             this.endConversation(sender);
         }
         if (agent.self_prompter.isPaused()) {
-            _resumeSelfPrompter();
+            await _resumeSelfPrompter();
         }
     }
 

--- a/tests/conversation_lifecycle.test.js
+++ b/tests/conversation_lifecycle.test.js
@@ -1,0 +1,32 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { Conversation, compileInMessages } from '../src/agent/conversation.js';
+
+test('reset clears a scheduled inbound timer and queued messages', async () => {
+    const convo = new Conversation('OtherBot');
+    let fired = false;
+    convo.queue({ message: 'stale' });
+    convo.inMessageTimer = setTimeout(() => { fired = true; }, 10);
+
+    convo.reset();
+    await new Promise(resolve => setTimeout(resolve, 20));
+
+    assert.equal(fired, false);
+    assert.equal(convo.inMessageTimer, null);
+    assert.deepEqual(convo.in_queue, []);
+    assert.equal(convo.active, false);
+    assert.equal(convo.ignore_until_start, false);
+});
+
+test('compileInMessages preserves message boundaries and the final envelope flags', () => {
+    const convo = new Conversation('OtherBot');
+    convo.queue({ message: 'first', start: true, end: false });
+    convo.queue({ message: 'second', start: false, end: true });
+
+    const compiled = compileInMessages(convo);
+
+    assert.equal(compiled.message, 'first\nsecond');
+    assert.equal(compiled.start, false);
+    assert.equal(compiled.end, true);
+    assert.deepEqual(convo.in_queue, []);
+});


### PR DESCRIPTION
## Merge status

**BLOCKED BY:** None

This PR has no known dependency on another PR in the #59-#90 series.

## Summary
Make conversation timers and queued messages cleanly reset, end, and reschedule across multi-agent conversations.

## Why
Stale timers and concatenated queued messages can survive conversation transitions and trigger responses after a conversation has already changed state.

## Changes
- Centralize timer cleanup on conversation reset/end.
- Clear the timer before rescheduling.
- Mark queued timers consumed before processing.
- Join batched messages with line breaks.
- Guard active-conversation access during teardown.

## Scope
Multi-agent conversation lifecycle only.