### PR TITLE
Store archived conversation history as append-only JSONL

### DIFF
--- a/src/agent/history.js
+++ b/src/agent/history.js
@@ -1,5 +1,5 @@
-import { writeFileSync, readFileSync, mkdirSync, existsSync } from 'fs';
-import { appendFile } from 'fs/promises';
+import { readFileSync, mkdirSync, existsSync } from 'fs';
+import { appendFile, writeFile } from 'fs/promises';
 import settings from './settings.js';
 
 export class History {
@@ -95,7 +95,7 @@ export class History {
                 taskStart: this.agent.task.taskStartTime,
                 last_sender: this.agent.last_sender
             };
-            writeFileSync(this.memory_fp, JSON.stringify(data, null, 2));
+            await writeFile(this.memory_fp, JSON.stringify(data, null, 2));
             console.log('Saved memory to:', this.memory_fp);
         } catch (error) {
             console.error('Failed to save history:', error);

--- a/src/agent/history.js
+++ b/src/agent/history.js
@@ -85,7 +85,7 @@ export class History {
         }
     }
 
-    async save() {
+    save() {
         try {
             const data = {
                 memory: this.memory,

--- a/src/agent/history.js
+++ b/src/agent/history.js
@@ -1,7 +1,5 @@
-import { writeFileSync, readFileSync, mkdirSync, existsSync } from 'fs';
-import { NPCData } from './npc/data.js';
+import { writeFileSync, readFileSync, mkdirSync, existsSync, appendFileSync } from 'fs';
 import settings from './settings.js';
-
 
 export class History {
     constructor(agent) {
@@ -21,7 +19,7 @@ export class History {
         this.max_messages = settings.max_messages;
 
         // Number of messages to remove from current history and save into memory
-        this.summary_chunk_size = 5; 
+        this.summary_chunk_size = 5;
         // chunking reduces expensive calls to promptMemSaving and appendFullHistory
         // and improves the quality of the memory summary
     }
@@ -31,7 +29,7 @@ export class History {
     }
 
     async summarizeMemories(turns) {
-        console.log("Storing memories...");
+        console.log('Storing memories...');
         this.memory = await this.agent.prompter.promptMemSaving(turns);
 
         if (this.memory.length > 500) {
@@ -39,22 +37,21 @@ export class History {
             this.memory += '...(Memory truncated to 500 chars. Compress it more next time)';
         }
 
-        console.log("Memory updated to: ", this.memory);
+        console.log('Memory updated to: ', this.memory);
     }
 
     async appendFullHistory(to_store) {
         if (this.full_history_fp === undefined) {
             const string_timestamp = new Date().toLocaleString().replace(/[/:]/g, '-').replace(/ /g, '').replace(/,/g, '_');
-            this.full_history_fp = `./bots/${this.name}/histories/${string_timestamp}.json`;
-            writeFileSync(this.full_history_fp, '[]', 'utf8');
+            this.full_history_fp = `./bots/${this.name}/histories/${string_timestamp}.jsonl`;
         }
+
         try {
-            const data = readFileSync(this.full_history_fp, 'utf8');
-            let full_history = JSON.parse(data);
-            full_history.push(...to_store);
-            writeFileSync(this.full_history_fp, JSON.stringify(full_history, null, 4), 'utf8');
+            const lines = to_store.map(turn => JSON.stringify(turn)).join('\n');
+            if (lines.length > 0)
+                appendFileSync(this.full_history_fp, lines + '\n', 'utf8');
         } catch (err) {
-            console.error(`Error reading ${this.name}'s full history file: ${err.message}`);
+            console.error(`Error appending ${this.name}'s full history file: ${err.message}`);
         }
     }
 

--- a/src/agent/history.js
+++ b/src/agent/history.js
@@ -1,4 +1,5 @@
-import { writeFileSync, readFileSync, mkdirSync, existsSync, appendFileSync } from 'fs';
+import { writeFileSync, readFileSync, mkdirSync, existsSync } from 'fs';
+import { appendFile } from 'fs/promises';
 import settings from './settings.js';
 
 export class History {
@@ -7,6 +8,7 @@ export class History {
         this.name = agent.name;
         this.memory_fp = `./bots/${this.name}/memory.json`;
         this.full_history_fp = undefined;
+        this.full_history_write = Promise.resolve();
 
         mkdirSync(`./bots/${this.name}/histories`, { recursive: true });
 
@@ -46,10 +48,17 @@ export class History {
             this.full_history_fp = `./bots/${this.name}/histories/${string_timestamp}.jsonl`;
         }
 
+        const lines = to_store.map(turn => JSON.stringify(turn)).join('\n');
+        if (lines.length === 0)
+            return;
+
+        const writeOperation = this.full_history_write.then(() =>
+            appendFile(this.full_history_fp, lines + '\n', 'utf8')
+        );
+        this.full_history_write = writeOperation.catch(() => {});
+
         try {
-            const lines = to_store.map(turn => JSON.stringify(turn)).join('\n');
-            if (lines.length > 0)
-                appendFileSync(this.full_history_fp, lines + '\n', 'utf8');
+            await writeOperation;
         } catch (err) {
             console.error(`Error appending ${this.name}'s full history file: ${err.message}`);
         }

--- a/src/agent/history.js
+++ b/src/agent/history.js
@@ -1,5 +1,5 @@
-import { readFileSync, mkdirSync, existsSync } from 'fs';
-import { appendFile, writeFile } from 'fs/promises';
+import { writeFileSync, readFileSync, mkdirSync, existsSync } from 'fs';
+import { appendFile } from 'fs/promises';
 import settings from './settings.js';
 
 export class History {
@@ -95,7 +95,7 @@ export class History {
                 taskStart: this.agent.task.taskStartTime,
                 last_sender: this.agent.last_sender
             };
-            await writeFile(this.memory_fp, JSON.stringify(data, null, 2));
+            writeFileSync(this.memory_fp, JSON.stringify(data, null, 2));
             console.log('Saved memory to:', this.memory_fp);
         } catch (error) {
             console.error('Failed to save history:', error);

--- a/tests/history.test.js
+++ b/tests/history.test.js
@@ -5,7 +5,7 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { History } from '../src/agent/history.js';
 
-test('archived history is appended as JSONL', async () => {
+test('archived history serializes concurrent appends as JSONL', async () => {
     const originalCwd = process.cwd();
     const dir = mkdtempSync(path.join(tmpdir(), 'mindcraft-history-'));
     process.chdir(dir);
@@ -20,8 +20,10 @@ test('archived history is appended as JSONL', async () => {
         };
         const history = new History(agent);
 
-        await history.appendFullHistory([{ role: 'user', content: 'one' }]);
-        await history.appendFullHistory([{ role: 'assistant', content: 'two' }]);
+        await Promise.all([
+            history.appendFullHistory([{ role: 'user', content: 'one' }]),
+            history.appendFullHistory([{ role: 'assistant', content: 'two' }]),
+        ]);
 
         const lines = readFileSync(history.full_history_fp, 'utf8').trim().split('\n').map(JSON.parse);
         assert.deepEqual(lines, [

--- a/tests/history.test.js
+++ b/tests/history.test.js
@@ -13,7 +13,7 @@ test('archived history serializes concurrent appends as JSONL', async () => {
     try {
         const agent = {
             name: 'TestBot',
-            prompter: { promptMemSaving: async () => '' },
+            prompter: { promptMemSaving: () => Promise.resolve('') },
             self_prompter: { state: 0, isStopped: () => true, prompt: '' },
             task: { taskStartTime: 0 },
             last_sender: null

--- a/tests/history.test.js
+++ b/tests/history.test.js
@@ -1,0 +1,35 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { History } from '../src/agent/history.js';
+
+test('archived history is appended as JSONL', async () => {
+    const originalCwd = process.cwd();
+    const dir = mkdtempSync(path.join(tmpdir(), 'mindcraft-history-'));
+    process.chdir(dir);
+
+    try {
+        const agent = {
+            name: 'TestBot',
+            prompter: { promptMemSaving: async () => '' },
+            self_prompter: { state: 0, isStopped: () => true, prompt: '' },
+            task: { taskStartTime: 0 },
+            last_sender: null
+        };
+        const history = new History(agent);
+
+        await history.appendFullHistory([{ role: 'user', content: 'one' }]);
+        await history.appendFullHistory([{ role: 'assistant', content: 'two' }]);
+
+        const lines = readFileSync(history.full_history_fp, 'utf8').trim().split('\n').map(JSON.parse);
+        assert.deepEqual(lines, [
+            { role: 'user', content: 'one' },
+            { role: 'assistant', content: 'two' }
+        ]);
+    } finally {
+        process.chdir(originalCwd);
+        rmSync(dir, { recursive: true, force: true });
+    }
+});


### PR DESCRIPTION
## Merge status

**BLOCKED BY:** None

This PR has no known dependency on another PR in the #59-#90 series.

## Summary
Change archived full-history storage from repeatedly rewriting one JSON array to append-only JSONL.

## Why
Re-reading and rewriting the full archive for every chunk becomes increasingly expensive as history grows and increases the amount of data at risk during interrupted writes.

## Changes
- Store archived history as `.jsonl`.
- Append one serialized turn per line.
- Keep active memory/history behavior unchanged.
- Add a regression test for repeated appends.

## Scope
Archived full-history persistence only.