### PR TITLE
Avoid shell interpolation when speaking model-generated TTS text

### DIFF
--- a/src/agent/speak.js
+++ b/src/agent/speak.js
@@ -22,10 +22,10 @@ export function speak(text, speak_model) {
     }
 
     speakingQueue.push(item);
-    if (!isSpeaking) processQueue();
+    if (!isSpeaking) void processQueue();
 }
 
-async function fetchRemoteAudio(txt, model) {
+function fetchRemoteAudio(txt, model) {
     function getModelUrl(prov) {
         if (prov === 'openai') return gptTTSConfig.baseUrl;
         if (prov === 'google') return geminiTTSConfig.baseUrl;
@@ -63,7 +63,7 @@ function cleanSystemTtsText(txt) {
 
 function finishQueueItem() {
     isSpeaking = false;
-    processQueue();
+    void processQueue();
 }
 
 function spawnSystemTts(txt) {
@@ -154,7 +154,11 @@ async function processQueue() {
             const finish = async () => {
                 if (finished) return;
                 finished = true;
-                try { await fs.unlink(tmpPath); } catch {}
+                try {
+                    await fs.unlink(tmpPath);
+                } catch {
+                    // Best-effort cleanup after playback.
+                }
                 finishQueueItem();
             };
             player.on('error', async (err) => {

--- a/src/agent/speak.js
+++ b/src/agent/speak.js
@@ -1,4 +1,4 @@
-import { exec, spawn } from 'child_process';
+import { spawn } from 'child_process';
 import { promises as fs } from 'fs';
 import os from 'os';
 import path from 'path';
@@ -14,12 +14,11 @@ export function speak(text, speak_model) {
     const item = { text, model, audioData: null, ready: null };
 
     if (model === 'system') {
-        // no preprocessing needed
         item.ready = Promise.resolve();
     } else {
-    item.ready = fetchRemoteAudio(text, model)
-        .then(data => { item.audioData = data; })
-        .catch(err => { item.error = err; });
+        item.ready = fetchRemoteAudio(text, model)
+            .then(data => { item.audioData = data; })
+            .catch(err => { item.error = err; });
     }
 
     speakingQueue.push(item);
@@ -49,9 +48,49 @@ async function fetchRemoteAudio(txt, model) {
     } else if (prov === 'google') {
         return geminiTTSConfig.sendAudioRequest(txt, mdl, voice, url);
     }
-    else {
-        throw new Error(`TTS Provider ${prov} is not supported.`);
+    throw new Error(`TTS Provider ${prov} is not supported.`);
+}
+
+function cleanSystemTtsText(txt) {
+    return txt
+        .replace(/\*\*/g, '')
+        .replace(/\*/g, '')
+        .replace(/`/g, '')
+        .replace(/#{1,6}\s*/g, '')
+        .replace(/[\r\n]+/g, ' ')
+        .trim();
+}
+
+function finishQueueItem() {
+    isSpeaking = false;
+    processQueue();
+}
+
+function spawnSystemTts(txt) {
+    const isWin = process.platform === 'win32';
+    const isMac = process.platform === 'darwin';
+    const cleanText = cleanSystemTtsText(txt);
+
+    if (isWin) {
+        const script = [
+            'Add-Type -AssemblyName System.Speech',
+            '$s = New-Object System.Speech.Synthesis.SpeechSynthesizer',
+            '$s.Rate = 2',
+            '$s.Speak($env:MINDCRAFT_TTS_TEXT)',
+            '$s.Dispose()'
+        ].join('; ');
+        return spawn('powershell', ['-NoProfile', '-Command', script], {
+            stdio: 'ignore',
+            windowsHide: true,
+            env: { ...process.env, MINDCRAFT_TTS_TEXT: cleanText }
+        });
     }
+
+    if (isMac) {
+        return spawn('say', [cleanText], { stdio: 'ignore' });
+    }
+
+    return spawn('espeak', [cleanText], { stdio: 'ignore' });
 }
 
 async function processQueue() {
@@ -60,113 +99,89 @@ async function processQueue() {
         isSpeaking = false;
         return;
     }
+
     const item = speakingQueue.shift();
-    const { text: txt, model, audioData } = item;
+    const { text: txt, model } = item;
     if (txt.trim() === '') {
-        isSpeaking = false;
-        processQueue();
+        finishQueueItem();
         return;
     }
 
     const isWin = process.platform === 'win32';
-    const isMac = process.platform === 'darwin';
 
-    // wait for preprocessing if needed
     try {
         await item.ready;
         if (item.error) throw item.error;
     } catch (err) {
         console.error('[TTS] preprocess error', err);
-        isSpeaking = false;
-        processQueue();
+        finishQueueItem();
         return;
     }
 
-  
-if (model === 'system') {
-    // Strip markdown formatting and collapse newlines to a single space
-    const txtClean = txt
-        .replace(/\*\*/g, '')
-        .replace(/\*/g, '')
-        .replace(/`/g, '')
-        .replace(/#{1,6}\s*/g, '')
-        .replace(/[\r\n]+/g, ' ')
-        .trim();
-
-    let cmd;
-
-    if (isWin) {
-        // Build the PS script as a plain string, escape only PS single-quotes
-        const ps = [
-            'Add-Type -AssemblyName System.Speech;',
-            '$s = New-Object System.Speech.Synthesis.SpeechSynthesizer;',
-            '$s.Rate = 2;',
-            `$s.Speak('${txtClean.replace(/'/g, "''")}');`,
-            '$s.Dispose()'
-        ].join(' ');
-
-        // Encode as UTF-16LE Base64 — bypasses ALL cmd.exe quoting entirely
-        const b64 = Buffer.from(ps, 'utf16le').toString('base64');
-        cmd = `powershell -NoProfile -EncodedCommand ${b64}`;
-
-    } else if (isMac) {
-        cmd = `say "${txtClean.replace(/"/g, '\\"')}"`;
-    } else {
-        cmd = `espeak "${txtClean.replace(/"/g, '\\"')}"`;
+    if (model === 'system') {
+        // Never interpolate model-controlled text into shell source or a command line.
+        const player = spawnSystemTts(txt);
+        let finished = false;
+        const finish = () => {
+            if (finished) return;
+            finished = true;
+            finishQueueItem();
+        };
+        player.on('error', (err) => {
+            console.error('TTS error', err);
+            finish();
+        });
+        player.on('exit', finish);
+        return;
     }
 
-    exec(cmd, err => {
-        if (err) console.error('TTS error', err);
-        isSpeaking = false;
-        processQueue();
-    });
-}
-    else {
-        // audioData was already fetched in speak()
-        const audioData = item.audioData;
+    const audioData = item.audioData;
+    if (!audioData) {
+        console.error('[TTS] No audio data ready');
+        finishQueueItem();
+        return;
+    }
 
-        if (!audioData) {
-            console.error('[TTS] No audio data ready');
-            isSpeaking = false;
-            processQueue();
-            return;
+    try {
+        if (isWin) {
+            const tmpPath = path.join(os.tmpdir(), `tts_${Date.now()}.mp3`);
+            await fs.writeFile(tmpPath, Buffer.from(audioData, 'base64'));
+
+            const player = spawn('ffplay', ['-nodisp', '-autoexit', '-loglevel', 'quiet', tmpPath], {
+                stdio: 'ignore', windowsHide: true
+            });
+            let finished = false;
+            const finish = async () => {
+                if (finished) return;
+                finished = true;
+                try { await fs.unlink(tmpPath); } catch {}
+                finishQueueItem();
+            };
+            player.on('error', async (err) => {
+                console.error('[TTS] ffplay error', err);
+                await finish();
+            });
+            player.on('exit', finish);
+        } else {
+            const player = spawn('ffplay', ['-nodisp', '-autoexit', 'pipe:0'], {
+                stdio: ['pipe', 'ignore', 'ignore']
+            });
+            player.stdin.write(Buffer.from(audioData, 'base64'));
+            player.stdin.end();
+            let finished = false;
+            const finish = () => {
+                if (finished) return;
+                finished = true;
+                finishQueueItem();
+            };
+            player.on('error', (err) => {
+                console.error('[TTS] ffplay error', err);
+                finish();
+            });
+            player.on('exit', finish);
         }
-
-        try {
-            if (isWin) {
-                const tmpPath = path.join(os.tmpdir(), `tts_${Date.now()}.mp3`);
-                await fs.writeFile(tmpPath, Buffer.from(audioData, 'base64'));
-
-                const player = spawn('ffplay', ['-nodisp', '-autoexit', '-loglevel', 'quiet', tmpPath], {
-                    stdio: 'ignore', windowsHide: true
-                });
-                player.on('error', async (err) => {
-                    console.error('[TTS] ffplay error', err);
-                    try { await fs.unlink(tmpPath); } catch {}
-                    isSpeaking = false;
-                    processQueue();
-                });
-                player.on('exit', async () => {
-                    try { await fs.unlink(tmpPath); } catch {}
-                    isSpeaking = false;
-                    processQueue();
-                });
-
-            } else {
-                const player = spawn('ffplay', ['-nodisp','-autoexit','pipe:0'], {
-                    stdio: ['pipe','ignore','ignore']
-                });
-                player.stdin.write(Buffer.from(audioData, 'base64'));
-                player.stdin.end();
-                player.on('exit', () => {
-                    isSpeaking = false;
-                    processQueue();
-                });
-            }
-        } catch (e) {
-            console.error('[TTS] Audio error', e);
-            isSpeaking = false;
-            processQueue();
-        }
+    } catch (e) {
+        console.error('[TTS] Audio error', e);
+        finishQueueItem();
     }
 }


### PR DESCRIPTION
## Merge status

**BLOCKED BY:** None

This PR has no known dependency on another PR in the #59-#90 series.

## Summary
Stop embedding model-generated speech text directly inside shell command strings.

## Why
Speech content is model-controlled. Interpolating it into PowerShell, `say`, or `espeak` command strings creates quoting bugs and a shell-injection surface.

## Changes
- Use `spawn()` with argument arrays/environment variables instead of shell interpolation.
- Keep Windows, macOS, and Linux system TTS support.
- Make queue completion idempotent across process error/exit events.
- Preserve remote TTS playback behavior.

## Scope
System TTS process execution and queue cleanup.