### PR TITLE
Wait for MindServer readiness before starting agents

### DIFF
--- a/main.js
+++ b/main.js
@@ -70,11 +70,13 @@ if (process.env.SETTINGS_JSON) {
     }
 }
 
-
-Mindcraft.init(false, settings.mindserver_port, settings.auto_open_ui);
+await Mindcraft.init(false, settings.mindserver_port, settings.auto_open_ui);
 
 for (let profile of settings.profiles) {
     const profile_json = JSON.parse(readFileSync(profile, 'utf8'));
     settings.profile = profile_json;
-    Mindcraft.createAgent(settings);
+    const result = await Mindcraft.createAgent(settings);
+    if (!result.success) {
+        console.error(`Failed to create agent ${profile_json.name}: ${result.error}`);
+    }
 }

--- a/src/mindcraft/mindcraft.js
+++ b/src/mindcraft/mindcraft.js
@@ -9,12 +9,35 @@ let agent_processes = {};
 let agent_count = 0;
 let mindserver_port = 8080;
 
+async function waitForServerListening(server) {
+    if (server.listening) return;
+
+    await new Promise((resolve, reject) => {
+        const onListening = () => {
+            cleanup();
+            resolve();
+        };
+        const onError = (error) => {
+            cleanup();
+            reject(error);
+        };
+        const cleanup = () => {
+            server.off('listening', onListening);
+            server.off('error', onError);
+        };
+
+        server.once('listening', onListening);
+        server.once('error', onError);
+    });
+}
+
 export async function init(host_public=false, port=8080, auto_open_ui=true) {
     if (connected) {
         console.error('Already initiliazed!');
         return;
     }
     mindserver = createMindServer(host_public, port);
+    await waitForServerListening(mindserver);
     mindserver_port = port;
     connected = true;
     if (auto_open_ui) {

--- a/src/mindcraft/mindcraft.js
+++ b/src/mindcraft/mindcraft.js
@@ -9,7 +9,7 @@ let agent_processes = {};
 let agent_count = 0;
 let mindserver_port = 8080;
 
-async function waitForServerListening(server) {
+export async function waitForServerListening(server) {
     if (server.listening) return;
 
     await new Promise((resolve, reject) => {

--- a/tests/mindserver_startup.test.js
+++ b/tests/mindserver_startup.test.js
@@ -1,0 +1,37 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import { waitForServerListening } from '../src/mindcraft/mindcraft.js';
+
+test('waitForServerListening returns immediately for an already-listening server', async () => {
+    const server = new EventEmitter();
+    server.listening = true;
+    await waitForServerListening(server);
+    assert.equal(server.listenerCount('listening'), 0);
+    assert.equal(server.listenerCount('error'), 0);
+});
+
+test('waitForServerListening resolves on listening and removes temporary listeners', async () => {
+    const server = new EventEmitter();
+    server.listening = false;
+
+    const ready = waitForServerListening(server);
+    server.emit('listening');
+    await ready;
+
+    assert.equal(server.listenerCount('listening'), 0);
+    assert.equal(server.listenerCount('error'), 0);
+});
+
+test('waitForServerListening rejects startup errors and removes temporary listeners', async () => {
+    const server = new EventEmitter();
+    server.listening = false;
+    const failure = new Error('listen failed');
+
+    const ready = waitForServerListening(server);
+    server.emit('error', failure);
+    await assert.rejects(ready, /listen failed/);
+
+    assert.equal(server.listenerCount('listening'), 0);
+    assert.equal(server.listenerCount('error'), 0);
+});


### PR DESCRIPTION
## Merge status

**BLOCKED BY:** None

This PR has no known dependency on another PR in the #59-#90 series.

## Summary
Await MindServer's listening state before starting agent processes and await agent creation from `main.js`.

## Why
Agent startup currently races MindServer initialization. On slower systems an agent can attempt to connect before the server is actually listening.

## Changes
- Wait for the HTTP server `listening` event during MindServer initialization.
- Await `Mindcraft.init(...)` in `main.js`.
- Await each agent creation and report startup failures.

## Scope
Startup sequencing only.