### PR TITLE
Parse environment setting overrides with explicit types

### DIFF
--- a/main.js
+++ b/main.js
@@ -3,6 +3,7 @@ import settings from './settings.js';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 import { readFileSync } from 'fs';
+import { parseBooleanEnv, parseIntegerEnv, parseJsonEnv } from './src/utils/env.js';
 
 function parseArguments() {
     return yargs(hideBin(process.argv))
@@ -38,35 +39,45 @@ if (args.task_path) {
 }
 
 // these environment variables override certain settings
-if (process.env.MINECRAFT_PORT) {
-    settings.port = process.env.MINECRAFT_PORT;
+if (process.env.MINECRAFT_PORT !== undefined) {
+    settings.port = parseIntegerEnv(process.env.MINECRAFT_PORT, 'MINECRAFT_PORT');
 }
-if (process.env.MINDSERVER_PORT) {
-    settings.mindserver_port = process.env.MINDSERVER_PORT;
+if (process.env.MINDSERVER_PORT !== undefined) {
+    settings.mindserver_port = parseIntegerEnv(process.env.MINDSERVER_PORT, 'MINDSERVER_PORT');
 }
-if (process.env.PROFILES && JSON.parse(process.env.PROFILES).length > 0) {
-    settings.profiles = JSON.parse(process.env.PROFILES);
+if (process.env.PROFILES !== undefined) {
+    const profiles = parseJsonEnv(process.env.PROFILES, 'PROFILES');
+    if (!Array.isArray(profiles)) {
+        throw new Error('PROFILES must be a JSON array.');
+    }
+    if (profiles.length > 0) {
+        settings.profiles = profiles;
+    }
 }
-if (process.env.INSECURE_CODING) {
-    settings.allow_insecure_coding = true;
+if (process.env.INSECURE_CODING !== undefined) {
+    settings.allow_insecure_coding = parseBooleanEnv(process.env.INSECURE_CODING, 'INSECURE_CODING');
 }
-if (process.env.BLOCKED_ACTIONS) {
-    settings.blocked_actions = JSON.parse(process.env.BLOCKED_ACTIONS);
+if (process.env.BLOCKED_ACTIONS !== undefined) {
+    const blockedActions = parseJsonEnv(process.env.BLOCKED_ACTIONS, 'BLOCKED_ACTIONS');
+    if (!Array.isArray(blockedActions)) {
+        throw new Error('BLOCKED_ACTIONS must be a JSON array.');
+    }
+    settings.blocked_actions = blockedActions;
 }
-if (process.env.MAX_MESSAGES) {
-    settings.max_messages = process.env.MAX_MESSAGES;
+if (process.env.MAX_MESSAGES !== undefined) {
+    settings.max_messages = parseIntegerEnv(process.env.MAX_MESSAGES, 'MAX_MESSAGES');
 }
-if (process.env.NUM_EXAMPLES) {
-    settings.num_examples = process.env.NUM_EXAMPLES;
+if (process.env.NUM_EXAMPLES !== undefined) {
+    settings.num_examples = parseIntegerEnv(process.env.NUM_EXAMPLES, 'NUM_EXAMPLES');
 }
-if (process.env.LOG_ALL) {
-    settings.log_all_prompts = process.env.LOG_ALL;
+if (process.env.LOG_ALL !== undefined) {
+    settings.log_all_prompts = parseBooleanEnv(process.env.LOG_ALL, 'LOG_ALL');
 }
 if (process.env.SETTINGS_JSON) {
     try {
-        Object.assign(settings, JSON.parse(process.env.SETTINGS_JSON));
+        Object.assign(settings, parseJsonEnv(process.env.SETTINGS_JSON, 'SETTINGS_JSON'));
     } catch (err) {
-        console.error("Failed to parse environment variable for SETTINGS_JSON:", err);
+        console.error('Failed to parse environment variable for SETTINGS_JSON:', err);
     }
 }
 

--- a/main.js
+++ b/main.js
@@ -38,7 +38,11 @@ if (args.task_path) {
     }
 }
 
-// these environment variables override certain settings
+// SETTINGS_JSON is the bulk override. Explicit typed environment variables below
+// intentionally take precedence over it.
+if (process.env.SETTINGS_JSON !== undefined) {
+    Object.assign(settings, parseJsonObjectEnv(process.env.SETTINGS_JSON, 'SETTINGS_JSON'));
+}
 if (process.env.MINECRAFT_PORT !== undefined) {
     settings.port = parseIntegerEnv(process.env.MINECRAFT_PORT, 'MINECRAFT_PORT', { min: -1, max: 65535 });
 }
@@ -72,9 +76,6 @@ if (process.env.NUM_EXAMPLES !== undefined) {
 }
 if (process.env.LOG_ALL !== undefined) {
     settings.log_all_prompts = parseBooleanEnv(process.env.LOG_ALL, 'LOG_ALL');
-}
-if (process.env.SETTINGS_JSON !== undefined) {
-    Object.assign(settings, parseJsonObjectEnv(process.env.SETTINGS_JSON, 'SETTINGS_JSON'));
 }
 
 

--- a/main.js
+++ b/main.js
@@ -3,7 +3,7 @@ import settings from './settings.js';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 import { readFileSync } from 'fs';
-import { parseBooleanEnv, parseIntegerEnv, parseJsonEnv } from './src/utils/env.js';
+import { parseBooleanEnv, parseIntegerEnv, parseJsonEnv, parseJsonObjectEnv } from './src/utils/env.js';
 
 function parseArguments() {
     return yargs(hideBin(process.argv))
@@ -40,10 +40,10 @@ if (args.task_path) {
 
 // these environment variables override certain settings
 if (process.env.MINECRAFT_PORT !== undefined) {
-    settings.port = parseIntegerEnv(process.env.MINECRAFT_PORT, 'MINECRAFT_PORT');
+    settings.port = parseIntegerEnv(process.env.MINECRAFT_PORT, 'MINECRAFT_PORT', { min: -1, max: 65535 });
 }
 if (process.env.MINDSERVER_PORT !== undefined) {
-    settings.mindserver_port = parseIntegerEnv(process.env.MINDSERVER_PORT, 'MINDSERVER_PORT');
+    settings.mindserver_port = parseIntegerEnv(process.env.MINDSERVER_PORT, 'MINDSERVER_PORT', { min: 1, max: 65535 });
 }
 if (process.env.PROFILES !== undefined) {
     const profiles = parseJsonEnv(process.env.PROFILES, 'PROFILES');
@@ -65,20 +65,16 @@ if (process.env.BLOCKED_ACTIONS !== undefined) {
     settings.blocked_actions = blockedActions;
 }
 if (process.env.MAX_MESSAGES !== undefined) {
-    settings.max_messages = parseIntegerEnv(process.env.MAX_MESSAGES, 'MAX_MESSAGES');
+    settings.max_messages = parseIntegerEnv(process.env.MAX_MESSAGES, 'MAX_MESSAGES', { min: 1 });
 }
 if (process.env.NUM_EXAMPLES !== undefined) {
-    settings.num_examples = parseIntegerEnv(process.env.NUM_EXAMPLES, 'NUM_EXAMPLES');
+    settings.num_examples = parseIntegerEnv(process.env.NUM_EXAMPLES, 'NUM_EXAMPLES', { min: 0 });
 }
 if (process.env.LOG_ALL !== undefined) {
     settings.log_all_prompts = parseBooleanEnv(process.env.LOG_ALL, 'LOG_ALL');
 }
-if (process.env.SETTINGS_JSON) {
-    try {
-        Object.assign(settings, parseJsonEnv(process.env.SETTINGS_JSON, 'SETTINGS_JSON'));
-    } catch (err) {
-        console.error('Failed to parse environment variable for SETTINGS_JSON:', err);
-    }
+if (process.env.SETTINGS_JSON !== undefined) {
+    Object.assign(settings, parseJsonObjectEnv(process.env.SETTINGS_JSON, 'SETTINGS_JSON'));
 }
 
 

--- a/main.js
+++ b/main.js
@@ -38,16 +38,14 @@ if (args.task_path) {
     }
 }
 
-// SETTINGS_JSON is the bulk override. Explicit typed environment variables below
-// intentionally take precedence over it.
-if (process.env.SETTINGS_JSON !== undefined) {
-    Object.assign(settings, parseJsonObjectEnv(process.env.SETTINGS_JSON, 'SETTINGS_JSON'));
-}
+// Collect explicit typed environment overrides first. SETTINGS_JSON is applied as
+// a bulk override below, then these explicit values are applied last.
+const explicitEnvOverrides = {};
 if (process.env.MINECRAFT_PORT !== undefined) {
-    settings.port = parseIntegerEnv(process.env.MINECRAFT_PORT, 'MINECRAFT_PORT', { min: -1, max: 65535 });
+    explicitEnvOverrides.port = parseIntegerEnv(process.env.MINECRAFT_PORT, 'MINECRAFT_PORT', { min: -1, max: 65535 });
 }
 if (process.env.MINDSERVER_PORT !== undefined) {
-    settings.mindserver_port = parseIntegerEnv(process.env.MINDSERVER_PORT, 'MINDSERVER_PORT', { min: 1, max: 65535 });
+    explicitEnvOverrides.mindserver_port = parseIntegerEnv(process.env.MINDSERVER_PORT, 'MINDSERVER_PORT', { min: 1, max: 65535 });
 }
 if (process.env.PROFILES !== undefined) {
     const profiles = parseJsonEnv(process.env.PROFILES, 'PROFILES');
@@ -55,28 +53,32 @@ if (process.env.PROFILES !== undefined) {
         throw new Error('PROFILES must be a JSON array.');
     }
     if (profiles.length > 0) {
-        settings.profiles = profiles;
+        explicitEnvOverrides.profiles = profiles;
     }
 }
 if (process.env.INSECURE_CODING !== undefined) {
-    settings.allow_insecure_coding = parseBooleanEnv(process.env.INSECURE_CODING, 'INSECURE_CODING');
+    explicitEnvOverrides.allow_insecure_coding = parseBooleanEnv(process.env.INSECURE_CODING, 'INSECURE_CODING');
 }
 if (process.env.BLOCKED_ACTIONS !== undefined) {
     const blockedActions = parseJsonEnv(process.env.BLOCKED_ACTIONS, 'BLOCKED_ACTIONS');
     if (!Array.isArray(blockedActions)) {
         throw new Error('BLOCKED_ACTIONS must be a JSON array.');
     }
-    settings.blocked_actions = blockedActions;
+    explicitEnvOverrides.blocked_actions = blockedActions;
 }
 if (process.env.MAX_MESSAGES !== undefined) {
-    settings.max_messages = parseIntegerEnv(process.env.MAX_MESSAGES, 'MAX_MESSAGES', { min: 1 });
+    explicitEnvOverrides.max_messages = parseIntegerEnv(process.env.MAX_MESSAGES, 'MAX_MESSAGES', { min: 1 });
 }
 if (process.env.NUM_EXAMPLES !== undefined) {
-    settings.num_examples = parseIntegerEnv(process.env.NUM_EXAMPLES, 'NUM_EXAMPLES', { min: 0 });
+    explicitEnvOverrides.num_examples = parseIntegerEnv(process.env.NUM_EXAMPLES, 'NUM_EXAMPLES', { min: 0 });
 }
 if (process.env.LOG_ALL !== undefined) {
-    settings.log_all_prompts = parseBooleanEnv(process.env.LOG_ALL, 'LOG_ALL');
+    explicitEnvOverrides.log_all_prompts = parseBooleanEnv(process.env.LOG_ALL, 'LOG_ALL');
 }
+if (process.env.SETTINGS_JSON !== undefined) {
+    Object.assign(settings, parseJsonObjectEnv(process.env.SETTINGS_JSON, 'SETTINGS_JSON'));
+}
+Object.assign(settings, explicitEnvOverrides);
 
 
 Mindcraft.init(false, settings.mindserver_port, settings.auto_open_ui);

--- a/main.js
+++ b/main.js
@@ -88,6 +88,7 @@ if (process.env.SETTINGS_JSON !== undefined) {
     }
 }
 
+
 Mindcraft.init(false, settings.mindserver_port, settings.auto_open_ui);
 
 for (let profile of settings.profiles) {

--- a/main.js
+++ b/main.js
@@ -38,8 +38,9 @@ if (args.task_path) {
     }
 }
 
-// Collect explicit typed environment overrides first. SETTINGS_JSON is applied as
-// a bulk override below, then these explicit values are applied last.
+// Parse the individual environment overrides with explicit types. Apply them
+// before SETTINGS_JSON to preserve the repository's existing precedence: the
+// bulk SETTINGS_JSON object remains the final environment-level override.
 const explicitEnvOverrides = {};
 if (process.env.MINECRAFT_PORT !== undefined) {
     explicitEnvOverrides.port = parseIntegerEnv(process.env.MINECRAFT_PORT, 'MINECRAFT_PORT', { min: -1, max: 65535 });
@@ -75,11 +76,17 @@ if (process.env.NUM_EXAMPLES !== undefined) {
 if (process.env.LOG_ALL !== undefined) {
     explicitEnvOverrides.log_all_prompts = parseBooleanEnv(process.env.LOG_ALL, 'LOG_ALL');
 }
-if (process.env.SETTINGS_JSON !== undefined) {
-    Object.assign(settings, parseJsonObjectEnv(process.env.SETTINGS_JSON, 'SETTINGS_JSON'));
-}
 Object.assign(settings, explicitEnvOverrides);
 
+if (process.env.SETTINGS_JSON !== undefined) {
+    try {
+        Object.assign(settings, parseJsonObjectEnv(process.env.SETTINGS_JSON, 'SETTINGS_JSON'));
+    } catch (err) {
+        // Preserve the previous startup behavior for a malformed bulk override:
+        // report it, then continue with the individually parsed environment values.
+        console.error('Failed to parse environment variable for SETTINGS_JSON:', err);
+    }
+}
 
 Mindcraft.init(false, settings.mindserver_port, settings.auto_open_ui);
 

--- a/src/utils/env.js
+++ b/src/utils/env.js
@@ -25,7 +25,7 @@ export function parseJsonEnv(value, name = 'environment variable') {
     try {
         return JSON.parse(value);
     } catch (error) {
-        throw new Error(`${name} must contain valid JSON: ${error.message}`);
+        throw new Error(`${name} must contain valid JSON: ${error.message}`, { cause: error });
     }
 }
 

--- a/src/utils/env.js
+++ b/src/utils/env.js
@@ -5,12 +5,20 @@ export function parseBooleanEnv(value, name = 'environment variable') {
     throw new Error(`${name} must be a boolean value (true/false, 1/0, yes/no, on/off).`);
 }
 
-export function parseIntegerEnv(value, name = 'environment variable') {
+export function parseIntegerEnv(value, name = 'environment variable', { min = Number.MIN_SAFE_INTEGER, max = Number.MAX_SAFE_INTEGER } = {}) {
     const normalized = String(value).trim();
     if (!/^-?\d+$/.test(normalized)) {
         throw new Error(`${name} must be an integer.`);
     }
-    return Number.parseInt(normalized, 10);
+
+    const parsed = Number.parseInt(normalized, 10);
+    if (!Number.isSafeInteger(parsed)) {
+        throw new Error(`${name} must be a safe integer.`);
+    }
+    if (parsed < min || parsed > max) {
+        throw new Error(`${name} must be between ${min} and ${max}.`);
+    }
+    return parsed;
 }
 
 export function parseJsonEnv(value, name = 'environment variable') {
@@ -19,4 +27,12 @@ export function parseJsonEnv(value, name = 'environment variable') {
     } catch (error) {
         throw new Error(`${name} must contain valid JSON: ${error.message}`);
     }
+}
+
+export function parseJsonObjectEnv(value, name = 'environment variable') {
+    const parsed = parseJsonEnv(value, name);
+    if (parsed === null || Array.isArray(parsed) || typeof parsed !== 'object') {
+        throw new Error(`${name} must contain a JSON object.`);
+    }
+    return parsed;
 }

--- a/src/utils/env.js
+++ b/src/utils/env.js
@@ -1,0 +1,22 @@
+export function parseBooleanEnv(value, name = 'environment variable') {
+    const normalized = String(value).trim().toLowerCase();
+    if (['1', 'true', 'yes', 'on'].includes(normalized)) return true;
+    if (['0', 'false', 'no', 'off'].includes(normalized)) return false;
+    throw new Error(`${name} must be a boolean value (true/false, 1/0, yes/no, on/off).`);
+}
+
+export function parseIntegerEnv(value, name = 'environment variable') {
+    const normalized = String(value).trim();
+    if (!/^-?\d+$/.test(normalized)) {
+        throw new Error(`${name} must be an integer.`);
+    }
+    return Number.parseInt(normalized, 10);
+}
+
+export function parseJsonEnv(value, name = 'environment variable') {
+    try {
+        return JSON.parse(value);
+    } catch (error) {
+        throw new Error(`${name} must contain valid JSON: ${error.message}`);
+    }
+}

--- a/tests/env.test.js
+++ b/tests/env.test.js
@@ -1,0 +1,22 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { parseBooleanEnv, parseIntegerEnv, parseJsonEnv } from '../src/utils/env.js';
+
+test('boolean parser does not treat "false" as truthy', () => {
+    assert.equal(parseBooleanEnv('true'), true);
+    assert.equal(parseBooleanEnv('false'), false);
+    assert.equal(parseBooleanEnv('1'), true);
+    assert.equal(parseBooleanEnv('0'), false);
+    assert.throws(() => parseBooleanEnv('maybe'), /must be a boolean/);
+});
+
+test('integer parser returns numbers and rejects mixed values', () => {
+    assert.equal(parseIntegerEnv('42'), 42);
+    assert.equal(parseIntegerEnv('-1'), -1);
+    assert.throws(() => parseIntegerEnv('42px'), /must be an integer/);
+});
+
+test('JSON parser includes the setting name in failures', () => {
+    assert.deepEqual(parseJsonEnv('["a"]'), ['a']);
+    assert.throws(() => parseJsonEnv('{', 'PROFILES'), /PROFILES/);
+});

--- a/tests/env.test.js
+++ b/tests/env.test.js
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { parseBooleanEnv, parseIntegerEnv, parseJsonEnv } from '../src/utils/env.js';
+import { parseBooleanEnv, parseIntegerEnv, parseJsonEnv, parseJsonObjectEnv } from '../src/utils/env.js';
 
 test('boolean parser does not treat "false" as truthy', () => {
     assert.equal(parseBooleanEnv('true'), true);
@@ -10,13 +10,18 @@ test('boolean parser does not treat "false" as truthy', () => {
     assert.throws(() => parseBooleanEnv('maybe'), /must be a boolean/);
 });
 
-test('integer parser returns numbers and rejects mixed values', () => {
+test('integer parser enforces format and configured bounds', () => {
     assert.equal(parseIntegerEnv('42'), 42);
-    assert.equal(parseIntegerEnv('-1'), -1);
+    assert.equal(parseIntegerEnv('-1', 'PORT', { min: -1, max: 65535 }), -1);
     assert.throws(() => parseIntegerEnv('42px'), /must be an integer/);
+    assert.throws(() => parseIntegerEnv('0', 'MINDSERVER_PORT', { min: 1, max: 65535 }), /between 1 and 65535/);
+    assert.throws(() => parseIntegerEnv('65536', 'PORT', { min: -1, max: 65535 }), /between -1 and 65535/);
 });
 
-test('JSON parser includes the setting name in failures', () => {
+test('JSON parsers include the setting name and object parser rejects arrays/null', () => {
     assert.deepEqual(parseJsonEnv('["a"]'), ['a']);
+    assert.deepEqual(parseJsonObjectEnv('{"a":1}', 'SETTINGS_JSON'), { a: 1 });
     assert.throws(() => parseJsonEnv('{', 'PROFILES'), /PROFILES/);
+    assert.throws(() => parseJsonObjectEnv('[]', 'SETTINGS_JSON'), /JSON object/);
+    assert.throws(() => parseJsonObjectEnv('null', 'SETTINGS_JSON'), /JSON object/);
 });


### PR DESCRIPTION
## Merge status

**BLOCKED BY:** None

This PR has no known dependency on another PR in the #59-#90 series.

## Summary
Parse boolean, integer, and JSON environment overrides explicitly instead of relying on JavaScript string truthiness.

## Why
Environment variables are strings, so values such as `INSECURE_CODING=false` are otherwise truthy. Numeric settings also remain strings unless converted.

## Changes
- Add reusable boolean/integer/JSON parsers.
- Apply typed parsing to supported environment overrides.
- Validate array-valued settings.
- Add parser regression tests.

## Compatibility
Common `true/false`, `1/0`, `yes/no`, and `on/off` boolean forms are supported.