### PR TITLE
Wait for camera initialization before capturing screenshots

### DIFF
--- a/src/agent/vision/camera.js
+++ b/src/agent/vision/camera.js
@@ -23,16 +23,21 @@ export class Camera extends EventEmitter {
         this.canvas = createCanvas(this.width, this.height);
         this.renderer = new THREE.WebGLRenderer({ canvas: this.canvas });
         this.viewer = new Viewer(this.renderer);
-        this.ready = this._init().then(() => {
-            this.emit('ready');
-        });
+        this.initError = null;
+        this.ready = this._init();
+        void this.ready.then(
+            () => this.emit('ready'),
+            (error) => {
+                this.initError = error;
+                console.error('Camera initialization failed:', error);
+            }
+        );
     }
 
     async _init () {
         const botPos = this.bot.entity.position;
         const center = new Vec3(botPos.x, botPos.y+this.bot.entity.height, botPos.z);
         this.viewer.setVersion(this.bot.version);
-        // Load world
         const worldView = new WorldView(this.bot.world, this.viewDistance, center);
         this.viewer.listen(worldView);
         worldView.listenToBot(this.bot);
@@ -41,9 +46,6 @@ export class Camera extends EventEmitter {
     }
 
     async capture() {
-        // Camera construction starts world loading asynchronously. A capture can
-        // be requested immediately after construction, so wait for initialization
-        // before dereferencing worldView.
         await this.ready;
 
         const center = new Vec3(this.bot.entity.position.x, this.bot.entity.position.y+this.bot.entity.height, this.bot.entity.position.z);

--- a/src/agent/vision/camera.js
+++ b/src/agent/vision/camera.js
@@ -23,11 +23,11 @@ export class Camera extends EventEmitter {
         this.canvas = createCanvas(this.width, this.height);
         this.renderer = new THREE.WebGLRenderer({ canvas: this.canvas });
         this.viewer = new Viewer(this.renderer);
-        this._init().then(() => {
+        this.ready = this._init().then(() => {
             this.emit('ready');
-        })
+        });
     }
-  
+
     async _init () {
         const botPos = this.bot.entity.position;
         const center = new Vec3(botPos.x, botPos.y+this.bot.entity.height, botPos.z);
@@ -39,8 +39,13 @@ export class Camera extends EventEmitter {
         await worldView.init(center);
         this.worldView = worldView;
     }
-  
+
     async capture() {
+        // Camera construction starts world loading asynchronously. A capture can
+        // be requested immediately after construction, so wait for initialization
+        // before dereferencing worldView.
+        await this.ready;
+
         const center = new Vec3(this.bot.entity.position.x, this.bot.entity.position.y+this.bot.entity.height, this.bot.entity.position.z);
         this.viewer.camera.position.set(center.x, center.y, center.z);
         await this.worldView.updatePosition(center);
@@ -53,7 +58,7 @@ export class Camera extends EventEmitter {
             quality: 100,
             progressive: false
         });
-        
+
         const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
         const filename = `screenshot_${timestamp}`;
 
@@ -65,14 +70,6 @@ export class Camera extends EventEmitter {
     }
 
     async _ensureScreenshotDirectory() {
-        let stats;
-        try {
-            stats = await fs.stat(this.fp);
-        } catch (e) {
-            if (!stats?.isDirectory()) {
-                await fs.mkdir(this.fp);
-            }
-        }
+        await fs.mkdir(this.fp, { recursive: true });
     }
 }
-  


### PR DESCRIPTION
## Merge status

**BLOCKED BY:** None

This PR has no known dependency on another PR in the #59-#90 series.

## Summary
Make camera capture wait for asynchronous world-view initialization before using it.

## Why
A screenshot can be requested immediately after constructing the camera, before `worldView` has finished initializing, causing a readiness race.

## Changes
- Store the camera initialization promise.
- Await it at the start of `capture()`.
- Simplify screenshot-directory creation with recursive `mkdir`.

## Scope
Vision camera initialization only.