### PR TITLE
Fix NPC goal-loop reentrancy and runtime edge cases

### DIFF
--- a/src/agent/npc/controller.js
+++ b/src/agent/npc/controller.js
@@ -160,7 +160,7 @@ export class NPCContoller {
         // If we need more blocks to complete a building, get those first
         let goals = this.temp_goals.concat(this.data.goals);
         if (this.data.curr_goal)
-            goals = goals.concat([this.data.curr_goal])
+            goals = goals.concat([this.data.curr_goal]);
         this.temp_goals = [];
 
         let acted = false;
@@ -204,7 +204,7 @@ export class NPCContoller {
                     this.temp_goals.push({
                         name: block_name,
                         quantity: res.missing[block_name]
-                    })
+                    });
                 }
                 if (res.acted) {
                     acted = true;

--- a/src/agent/npc/controller.js
+++ b/src/agent/npc/controller.js
@@ -4,8 +4,6 @@ import { ItemGoal } from './item_goal.js';
 import { BuildGoal } from './build_goal.js';
 import { itemSatisfied, rotateXZ } from './utils.js';
 import * as skills from '../library/skills.js';
-import * as world from '../library/world.js';
-import * as mc from '../../utils/mcdata.js';
 
 
 export class NPCContoller {
@@ -17,11 +15,13 @@ export class NPCContoller {
         this.build_goal = new BuildGoal(agent);
         this.constructions = {};
         this.last_goals = {};
+        this.goal_tick_running = false;
     }
 
     getBuiltPositions() {
         let positions = [];
         for (let name in this.data.built) {
+            if (!this.constructions[name]) continue;
             let position = this.data.built[name].position;
             let offset = this.constructions[name].offset;
             let sizex = this.constructions[name].blocks[0][0].length;
@@ -66,15 +66,22 @@ export class NPCContoller {
         }
 
         this.agent.bot.on('idle', async () => {
+            if (this.goal_tick_running) return;
             if (this.data.goals.length === 0 && !this.data.curr_goal) return;
-            // Wait a while for inputs before acting independently
-            await new Promise((resolve) => setTimeout(resolve, 5000));
-            if (!this.agent.isIdle()) return;
 
-            // Persue goal
-            if (!this.agent.actions.resume_func) {
-                this.executeNext();
-                this.agent.history.save();
+            this.goal_tick_running = true;
+            try {
+                // Wait a while for inputs before acting independently
+                await new Promise((resolve) => setTimeout(resolve, 5000));
+                if (!this.agent.isIdle()) return;
+
+                // Pursue goal
+                if (!this.agent.actions.resume_func) {
+                    await this.executeNext();
+                    await this.agent.history.save();
+                }
+            } finally {
+                this.goal_tick_running = false;
             }
         });
     }
@@ -90,7 +97,7 @@ export class NPCContoller {
         if (!this.data.do_set_goal) return;
 
         let past_goals = {...this.last_goals};
-        for (let goal in this.data.goals) {
+        for (let goal of this.data.goals) {
             if (past_goals[goal.name] === undefined) past_goals[goal.name] = true;
         }
         let res = await this.agent.prompter.promptGoalSetting(this.agent.history.getHistory(), past_goals);
@@ -108,7 +115,7 @@ export class NPCContoller {
             await skills.moveAway(this.agent.bot, 2);
         });
 
-        if (!this.data.do_routine || this.agent.bot.time.timeOfDay < 13000) { 
+        if (!this.data.do_routine || this.agent.bot.time.timeOfDay < 13000) {
             // Exit any buildings
             let building = this.currentBuilding();
             if (building == this.data.home) {
@@ -132,9 +139,11 @@ export class NPCContoller {
             let building = this.currentBuilding();
             if (this.data.home !== null && (building === null || building != this.data.home)) {
                 let door_pos = this.getBuildingDoor(this.data.home);
-                await this.agent.actions.runAction('npc:returnHome', async () => {
-                    await skills.useDoor(this.agent.bot, door_pos);
-                });
+                if (door_pos) {
+                    await this.agent.actions.runAction('npc:returnHome', async () => {
+                        await skills.useDoor(this.agent.bot, door_pos);
+                    });
+                }
             }
 
             // Go to bed
@@ -178,6 +187,10 @@ export class NPCContoller {
                     );
                 } else {
                     res = await this.build_goal.executeNext(this.constructions[goal.name]);
+                    if (!res?.position) {
+                        this.last_goals[goal.name] = false;
+                        continue;
+                    }
                     this.data.built[goal.name] = {
                         name: goal.name,
                         position: res.position,
@@ -208,6 +221,7 @@ export class NPCContoller {
     currentBuilding() {
         let bot_pos = this.agent.bot.entity.position;
         for (let name in this.data.built) {
+            if (!this.constructions[name]) continue;
             let pos = this.data.built[name].position;
             let offset = this.constructions[name].offset;
             let sizex = this.constructions[name].blocks[0][0].length;
@@ -224,7 +238,7 @@ export class NPCContoller {
     }
 
     getBuildingDoor(name) {
-        if (name === null || this.data.built[name] === undefined) return null;
+        if (name === null || this.data.built[name] === undefined || !this.constructions[name]) return null;
         let door_x = null;
         let door_z = null;
         let door_y = null;

--- a/src/agent/npc/controller.js
+++ b/src/agent/npc/controller.js
@@ -178,8 +178,8 @@ export class NPCContoller {
 
             // Build construction goal
             else {
-                let res = null;
-                if (this.data.built.hasOwnProperty(goal.name)) {
+                let res;
+                if (Object.prototype.hasOwnProperty.call(this.data.built, goal.name)) {
                     res = await this.build_goal.executeNext(
                         this.constructions[goal.name],
                         this.data.built[goal.name].position,

--- a/src/agent/npc/item_goal.js
+++ b/src/agent/npc/item_goal.js
@@ -17,7 +17,7 @@ const blacklist = [
     'crimson',
     'warped',
     'dye'
-]
+];
 
 
 class ItemNode {
@@ -218,7 +218,7 @@ class ItemWrapper {
                 if (includes_blacklisted) break;
             }
             if (includes_blacklisted) continue;
-            this.add_method(new ItemNode(this.manager, this, this.name).setRecipe(recipe))
+            this.add_method(new ItemNode(this.manager, this, this.name).setRecipe(recipe));
         }
 
         let block_sources = mc.getItemBlockSources(this.name);
@@ -262,7 +262,7 @@ class ItemWrapper {
                 best_method = method;
             }
         }
-        return best_method
+        return best_method;
     }
 
     isDone(q=1) {

--- a/src/agent/npc/item_goal.js
+++ b/src/agent/npc/item_goal.js
@@ -160,7 +160,7 @@ class ItemNode {
             await skills.smeltItem(this.manager.agent.bot, to_smelt_name, to_smelt_quantity);
         } else if (this.type === 'hunt') {
             for (let i=0; i<quantity; i++) {
-                res = await skills.attackNearest(this.manager.agent.bot, this.source);
+                const res = await skills.attackNearest(this.manager.agent.bot, this.source);
                 if (!res || this.manager.agent.bot.interrupt_code)
                     break;
             }
@@ -204,22 +204,21 @@ class ItemWrapper {
     }
 
     createChildren() {
-        let recipes = mc.getItemCraftingRecipes(this.name).map(([recipe, craftedCount]) => recipe);
-        if (recipes) {
-            for (let recipe of recipes) {
-                let includes_blacklisted = false;
-                for (let ingredient in recipe) {
-                    for (let match of blacklist) {
-                        if (ingredient.includes(match)) {
-                            includes_blacklisted = true;
-                            break;
-                        }
+        const craftingRecipes = mc.getItemCraftingRecipes(this.name) || [];
+        let recipes = craftingRecipes.map(([recipe]) => recipe);
+        for (let recipe of recipes) {
+            let includes_blacklisted = false;
+            for (let ingredient in recipe) {
+                for (let match of blacklist) {
+                    if (ingredient.includes(match)) {
+                        includes_blacklisted = true;
+                        break;
                     }
-                    if (includes_blacklisted) break;
                 }
-                if (includes_blacklisted) continue;
-                this.add_method(new ItemNode(this.manager, this, this.name).setRecipe(recipe))
+                if (includes_blacklisted) break;
             }
+            if (includes_blacklisted) continue;
+            this.add_method(new ItemNode(this.manager, this, this.name).setRecipe(recipe))
         }
 
         let block_sources = mc.getItemBlockSources(this.name);
@@ -315,8 +314,10 @@ export class ItemGoal {
         let quantity = next_info.quantity;
 
         // Prevent unnecessary attempts to obtain blocks that are not nearby
-        if (next.type === 'block' && !world.getNearbyBlockTypes(this.agent.bot).includes(next.source) ||
-                next.type === 'hunt' && !world.getNearbyEntityTypes(this.agent.bot).includes(next.source)) {
+        const sourceUnavailable =
+            (next.type === 'block' && !world.getNearbyBlockTypes(this.agent.bot).includes(next.source)) ||
+            (next.type === 'hunt' && !world.getNearbyEntityTypes(this.agent.bot).includes(next.source));
+        if (sourceUnavailable) {
             next.fails += 1;
 
             // If the bot has failed to obtain the block before, explore

--- a/tests/npc_controller.test.js
+++ b/tests/npc_controller.test.js
@@ -2,7 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { NPCContoller } from '../src/agent/npc/controller.js';
 
-function makeAgent(npc, promptGoalSetting = async () => null) {
+function makeAgent(npc, promptGoalSetting = () => Promise.resolve(null)) {
     return {
         prompter: {
             profile: { npc },
@@ -22,9 +22,9 @@ test('setGoal reports configured goal names instead of array indexes', async () 
             ],
             do_set_goal: true,
         },
-        async (_history, pastGoals) => {
+        (_history, pastGoals) => {
             observedPastGoals = pastGoals;
-            return null;
+            return Promise.resolve(null);
         }
     );
 

--- a/tests/npc_controller.test.js
+++ b/tests/npc_controller.test.js
@@ -1,0 +1,49 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { NPCContoller } from '../src/agent/npc/controller.js';
+
+function makeAgent(npc, promptGoalSetting = async () => null) {
+    return {
+        prompter: {
+            profile: { npc },
+            promptGoalSetting,
+        },
+        history: { getHistory: () => [] },
+    };
+}
+
+test('setGoal reports configured goal names instead of array indexes', async () => {
+    let observedPastGoals;
+    const agent = makeAgent(
+        {
+            goals: [
+                { name: 'oak_log', quantity: 2 },
+                { name: 'coal', quantity: 1 },
+            ],
+            do_set_goal: true,
+        },
+        async (_history, pastGoals) => {
+            observedPastGoals = pastGoals;
+            return null;
+        }
+    );
+
+    const controller = new NPCContoller(agent);
+    await controller.setGoal();
+
+    assert.deepEqual(observedPastGoals, { oak_log: true, coal: true });
+});
+
+test('built-position queries ignore stale construction records safely', () => {
+    const controller = new NPCContoller(makeAgent({
+        built: {
+            deleted_blueprint: {
+                position: { x: 0, y: 64, z: 0 },
+                orientation: 0,
+            },
+        },
+    }));
+
+    assert.deepEqual(controller.getBuiltPositions(), []);
+    assert.equal(controller.getBuildingDoor('deleted_blueprint'), null);
+});


### PR DESCRIPTION
## Merge status

**BLOCKED BY:** None

This PR has no known dependency on another PR in the #59-#90 series.

## Summary
Harden the NPC goal runtime against overlapping idle ticks and several missing/null runtime states.

## Why
Repeated idle events can start overlapping goal work, missing construction data can be dereferenced, and a few item-goal paths contain unsafe assumptions.

## Changes
- Prevent concurrent NPC goal ticks.
- Await goal execution and history saves.
- Guard missing construction/door/build-position data.
- Handle failed construction placement selection.
- Fix hunt result scoping.
- Harden recipe/source availability checks.

## Scope
NPC runtime correctness; no new NPC behavior is introduced.