### PR TITLE
Load per-agent settings before importing runtime modules

### DIFF
--- a/src/agent/mindserver_proxy.js
+++ b/src/agent/mindserver_proxy.js
@@ -1,7 +1,6 @@
 import { io } from 'socket.io-client';
-import convoManager from './conversation.js';
 import { setSettings } from './settings.js';
-import { getFullState } from './library/full_state.js';
+import rootSettings from '../../settings.js';
 
 // agent's individual connection to the mindserver
 // always connect to localhost
@@ -11,30 +10,66 @@ class MindServerProxy {
         if (MindServerProxy.instance) {
             return MindServerProxy.instance;
         }
-        
+
         this.socket = null;
         this.connected = false;
         this.agents = [];
+        this.convoManager = null;
+        this.getFullState = null;
         MindServerProxy.instance = this;
     }
 
     async connect(name, port) {
         if (this.connected) return;
-        
+
         this.name = name;
         this.socket = io(`http://localhost:${port}`);
 
         await new Promise((resolve, reject) => {
-            this.socket.on('connect', resolve);
-            this.socket.on('connect_error', (err) => {
-                console.error('Connection failed:', err);
-                reject(err);
+            this.socket.once('connect', resolve);
+            this.socket.once('connect_error', reject);
+        });
+
+        // Load this process's per-agent settings before importing the Agent
+        // runtime. Several runtime modules snapshot settings during module
+        // evaluation, so importing them before this handshake can freeze the
+        // root/default values instead of the settings for this agent.
+        const response = await new Promise((resolve, reject) => {
+            const timeout = setTimeout(() => {
+                reject(new Error('Settings request timed out after 5 seconds'));
+            }, 5000);
+
+            this.socket.emit('get-settings', name, (settingsResponse) => {
+                clearTimeout(timeout);
+                if (settingsResponse.error) {
+                    reject(new Error(settingsResponse.error));
+                    return;
+                }
+                resolve(settingsResponse);
             });
         });
 
+        setSettings(response.settings);
+        Object.assign(rootSettings, response.settings);
+
+        // conversation.js and full_state.js pull in commands/skills/mcdata. Delay
+        // both import chains until after the settings handshake has populated
+        // the child-process settings objects.
+        const [{ default: convoManager }, { getFullState }] = await Promise.all([
+            import('./conversation.js'),
+            import('./library/full_state.js'),
+        ]);
+        this.convoManager = convoManager;
+        this.getFullState = getFullState;
+
+        this._registerSocketHandlers();
         this.connected = true;
         console.log(name, 'connected to MindServer');
 
+        this.socket.emit('connect-agent-process', name);
+    }
+
+    _registerSocketHandlers() {
         this.socket.on('disconnect', () => {
             console.log('Disconnected from MindServer');
             this.connected = false;
@@ -44,12 +79,12 @@ class MindServerProxy {
         });
 
         this.socket.on('chat-message', (agentName, json) => {
-            convoManager.receiveFromBot(agentName, json);
+            this.convoManager.receiveFromBot(agentName, json);
         });
 
         this.socket.on('agents-status', (agents) => {
             this.agents = agents;
-            convoManager.updateAgents(agents);
+            this.convoManager.updateAgents(agents);
             if (this.agent?.task) {
                 console.log(this.agent.name, 'updating available agents');
                 this.agent.task.updateAvailableAgents(agents);
@@ -58,12 +93,12 @@ class MindServerProxy {
 
         this.socket.on('restart-agent', (agentName) => {
             console.log(`Restarting agent: ${agentName}`);
-            this.agent.cleanKill();
+            this.agent?.cleanKill();
         });
-		
+
         this.socket.on('send-message', (data) => {
             try {
-                this.agent.respondFunc(data.from, data.message);
+                this.agent?.respondFunc(data.from, data.message);
             } catch (error) {
                 console.error('Error: ', JSON.stringify(error, Object.getOwnPropertyNames(error)));
             }
@@ -71,29 +106,16 @@ class MindServerProxy {
 
         this.socket.on('get-full-state', (callback) => {
             try {
-                const state = getFullState(this.agent);
+                if (!this.agent || !this.getFullState) {
+                    callback(null);
+                    return;
+                }
+                const state = this.getFullState(this.agent);
                 callback(state);
             } catch (error) {
                 console.error('Error getting full state:', error);
                 callback(null);
             }
-        });
-
-        // Request settings and wait for response
-        await new Promise((resolve, reject) => {
-            const timeout = setTimeout(() => {
-                reject(new Error('Settings request timed out after 5 seconds'));
-            }, 5000);
-
-            this.socket.emit('get-settings', name, (response) => {
-                clearTimeout(timeout);
-                if (response.error) {
-                    return reject(new Error(response.error));
-                }
-                setSettings(response.settings);
-                this.socket.emit('connect-agent-process', name);
-                resolve();
-            });
         });
     }
 

--- a/src/process/init_agent.js
+++ b/src/process/init_agent.js
@@ -36,7 +36,7 @@ const argv = yargs(args)
     })
     .argv;
 
-(async () => {
+await (async () => {
     try {
         console.log('Connecting to MindServer');
         await serverProxy.connect(argv.name, argv.port);

--- a/src/process/init_agent.js
+++ b/src/process/init_agent.js
@@ -1,4 +1,3 @@
-import { Agent } from '../agent/agent.js';
 import { serverProxy } from '../agent/mindserver_proxy.js';
 import yargs from 'yargs';
 
@@ -41,6 +40,12 @@ const argv = yargs(args)
     try {
         console.log('Connecting to MindServer');
         await serverProxy.connect(argv.name, argv.port);
+
+        // Import Agent only after connect() has received this process's settings.
+        // Agent's dependency graph includes modules that read settings at module
+        // initialization time.
+        const { Agent } = await import('../agent/agent.js');
+
         console.log('Starting agent');
         const agent = new Agent();
         serverProxy.setAgent(agent);


### PR DESCRIPTION
## Merge status

**BLOCKED BY:** None

This PR has no known dependency on another PR in the #59-#90 series.

## Summary
Ensure each agent process receives its MindServer settings before importing modules that snapshot settings during module initialization.

## Why
Some runtime modules read settings at import time. Importing the full agent dependency graph before the per-agent settings handshake can freeze root/default values into a child process.

## Changes
- Complete the settings handshake before importing conversation/full-state dependencies.
- Synchronize the child-process root settings object.
- Dynamically import `Agent` only after connection/settings initialization.
- Register socket handlers after the per-agent runtime dependencies are ready.

## Scope
Per-agent process initialization and settings isolation.