### PR TITLE
Respect failed and timed-out actions in BuildGoal

### DIFF
--- a/src/agent/npc/build_goal.js
+++ b/src/agent/npc/build_goal.js
@@ -1,7 +1,6 @@
 import { Vec3 } from 'vec3';
 import * as skills from '../library/skills.js';
 import * as world from '../library/world.js';
-import * as mc from '../../utils/mcdata.js';
 import { blockSatisfied, getTypeOfGeneric, rotateXZ } from './utils.js';
 
 
@@ -14,7 +13,7 @@ export class BuildGoal {
         if (!this.agent.isIdle())
             return false;
         let res = await this.agent.actions.runAction('BuildGoal', func);
-        return !res.interrupted;
+        return res.success && !res.interrupted && !res.timedout;
     }
 
     async executeNext(goal, position=null, orientation=null) {
@@ -26,6 +25,9 @@ export class BuildGoal {
                 position = world.getNearestFreeSpace(this.agent.bot, sizex - x, 16);
                 if (position) break;
             }
+        }
+        if (!position) {
+            return {missing: {}, acted: false, position: null, orientation};
         }
         if (orientation === null) {
             orientation = Math.floor(Math.random() * 4);
@@ -64,6 +66,7 @@ export class BuildGoal {
                                     await skills.placeBlock(this.agent.bot, block_typed, world_pos.x, world_pos.y, world_pos.z);
                                 });
                                 if (!res) return {missing: missing, acted: acted, position: position, orientation: orientation};
+                                inventory[block_typed]--;
                             } else {
                                 if (missing[block_typed] === undefined)
                                     missing[block_typed] = 0;

--- a/src/agent/npc/build_goal.js
+++ b/src/agent/npc/build_goal.js
@@ -48,24 +48,23 @@ export class BuildGoal {
                     let world_pos = new Vec3(position.x + x, position.y + y, position.z + z);
                     let current_block = this.agent.bot.blockAt(world_pos);
 
-                    let res = null;
                     if (current_block !== null && !blockSatisfied(block_name, current_block)) {
                         acted = true;
 
                         if (current_block.name !== 'air') {
-                            res = await this.wrapSkill(async () => {
+                            const breakSucceeded = await this.wrapSkill(async () => {
                                 await skills.breakBlockAt(this.agent.bot, world_pos.x, world_pos.y, world_pos.z);
                             });
-                            if (!res) return {missing: missing, acted: acted, position: position, orientation: orientation};
+                            if (!breakSucceeded) return {missing: missing, acted: acted, position: position, orientation: orientation};
                         }
 
                         if (block_name !== 'air') {
                             let block_typed = getTypeOfGeneric(this.agent.bot, block_name);
                             if (inventory[block_typed] > 0) {
-                                res = await this.wrapSkill(async () => {
+                                const placementSucceeded = await this.wrapSkill(async () => {
                                     await skills.placeBlock(this.agent.bot, block_typed, world_pos.x, world_pos.y, world_pos.z);
                                 });
-                                if (!res) return {missing: missing, acted: acted, position: position, orientation: orientation};
+                                if (!placementSucceeded) return {missing: missing, acted: acted, position: position, orientation: orientation};
                                 inventory[block_typed]--;
                             } else {
                                 if (missing[block_typed] === undefined)

--- a/tests/build_goal.test.js
+++ b/tests/build_goal.test.js
@@ -1,0 +1,39 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { BuildGoal } from '../src/agent/npc/build_goal.js';
+
+function makeGoal(result, idle = true) {
+    const agent = {
+        isIdle: () => idle,
+        actions: {
+            runAction: async (_label, func) => {
+                await func();
+                return result;
+            },
+        },
+    };
+    return new BuildGoal(agent);
+}
+
+test('wrapSkill accepts only successful non-interrupted non-timed-out actions', async () => {
+    assert.equal(await makeGoal({ success: true, interrupted: false, timedout: false }).wrapSkill(async () => {}), true);
+    assert.equal(await makeGoal({ success: false, interrupted: false, timedout: false }).wrapSkill(async () => {}), false);
+    assert.equal(await makeGoal({ success: true, interrupted: true, timedout: false }).wrapSkill(async () => {}), false);
+    assert.equal(await makeGoal({ success: true, interrupted: false, timedout: true }).wrapSkill(async () => {}), false);
+});
+
+test('wrapSkill refuses to start while the agent is busy', async () => {
+    let called = false;
+    const goal = new BuildGoal({
+        isIdle: () => false,
+        actions: {
+            runAction: async () => {
+                called = true;
+                return { success: true, interrupted: false, timedout: false };
+            },
+        },
+    });
+
+    assert.equal(await goal.wrapSkill(async () => {}), false);
+    assert.equal(called, false);
+});

--- a/tests/build_goal.test.js
+++ b/tests/build_goal.test.js
@@ -27,9 +27,9 @@ test('wrapSkill refuses to start while the agent is busy', async () => {
     const goal = new BuildGoal({
         isIdle: () => false,
         actions: {
-            runAction: async () => {
+            runAction: () => {
                 called = true;
-                return { success: true, interrupted: false, timedout: false };
+                return Promise.resolve({ success: true, interrupted: false, timedout: false });
             },
         },
     });


### PR DESCRIPTION
## Merge status

**BLOCKED BY:** #64

Merge #64 first so this PR is based on the corrected ActionManager state behavior.

## Summary
Make `BuildGoal` treat failed or timed-out actions as failures instead of considering every non-interrupted action successful.

## Why
`ActionManager.runAction()` exposes `success`, `interrupted`, and `timedout`. Ignoring `success`/`timedout` can allow building logic to advance after an action did not actually complete.

## Changes
- Require successful, non-interrupted, non-timed-out action results.
- Handle failure to find a build position.
- Decrement the local inventory snapshot after successful placement.

## Dependencies

Depends on #64.

## Scope
NPC building result handling only.