### PR TITLE
Await generated-code templates before code generation

### DIFF
--- a/src/agent/coder.js
+++ b/src/agent/coder.js
@@ -129,7 +129,7 @@ export class Coder {
         if (missingSkills.length > 0) {
             result += 'These functions do not exist:\n';
             result += missingSkills.join('\n');
-            console.log(result)
+            console.log(result);
             return result;
         }
 
@@ -193,7 +193,7 @@ export class Coder {
 
     _sanitizeCode(code) {
         code = code.trim();
-        const remove_strs = ['Javascript', 'javascript', 'js']
+        const remove_strs = ['Javascript', 'javascript', 'js'];
         for (let r of remove_strs) {
             if (code.startsWith(r)) {
                 code = code.slice(r.length);

--- a/src/agent/coder.js
+++ b/src/agent/coder.js
@@ -1,4 +1,5 @@
-import { writeFile, readFile, mkdirSync } from 'fs';
+import { writeFile, mkdirSync } from 'fs';
+import { readFile } from 'fs/promises';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { makeCompartment, lockdown } from './library/lockdown.js';
@@ -17,21 +18,21 @@ export class Coder {
         this.code_template = '';
         this.code_lint_template = '';
 
-        readFile(path.join(__dirname, '../../bots/execTemplate.js'), 'utf8', (err, data) => {
-            if (err) throw err;
-            this.code_template = data;
-        });
-        readFile(path.join(__dirname, '../../bots/lintTemplate.js'), 'utf8', (err, data) => {
-            if (err) throw err;
-            this.code_lint_template = data;
-        });
+        this.ready = this._loadTemplates();
         mkdirSync('.' + this.fp, { recursive: true });
     }
 
+    async _loadTemplates() {
+        [this.code_template, this.code_lint_template] = await Promise.all([
+            readFile(path.join(__dirname, '../../bots/execTemplate.js'), 'utf8'),
+            readFile(path.join(__dirname, '../../bots/lintTemplate.js'), 'utf8')
+        ]);
+    }
+
     async generateCode(agent_history) {
+        await this.ready;
         this.agent.bot.modes.pause('unstuck');
         lockdown();
-        // this message history is transient and only maintained in this function
         let messages = agent_history.getHistory(); 
         messages.push({role: 'system', content: 'Code generation started. Write code in codeblock in your response:'});
 
@@ -54,9 +55,8 @@ export class Coder {
                         role: 'assistant', 
                         content: res.substring(0, res.indexOf('!newAction'))
                     });
-                    continue; // using newaction will continue the loop
+                    continue;
                 }
-                
                 if (no_code_failures >= MAX_NO_CODE) {
                     console.warn("Action failed, agent would not write code.");
                     return 'Action failed, agent would not write code.';
@@ -94,16 +94,12 @@ export class Coder {
             } catch (e) {
                 if (this.agent.bot.interrupt_code)
                     return null;
-                
                 console.warn('Generated code threw error: ' + e.toString());
                 console.warn('trying again...');
 
                 const code_output = this.agent.actions.getBotOutputSummary();
 
-                messages.push({
-                    role: 'assistant',
-                    content: res
-                });
+                messages.push({ role: 'assistant', content: res });
                 messages.push({
                     role: 'system',
                     content: `Code Output:\n${code_output}\nCODE EXECUTION THREW ERROR: ${e.toString()}\n Please try again:`
@@ -113,18 +109,18 @@ export class Coder {
         return `Code generation failed after ${MAX_ATTEMPTS} attempts.`;
     }
     
-    async  _lintCode(code) {
+    async _lintCode(code) {
         let result = '#### CODE ERROR INFO ###\n';
         const codeNoComments = code.replace(/\/\/.*$/gm, '').replace(/\/\*[\s\S]*?\*\//g, '');
         const skillRegex = /((?:skills|world)\.(.*?))\(/g;
-        const skills = [];
+        const usedSkills = [];
         let match;
         while ((match = skillRegex.exec(codeNoComments)) !== null) {
-            skills.push(match[1]);
+            usedSkills.push(match[1]);
         }
         const allDocs = await this.agent.prompter.skill_libary.getAllSkillDocs();
         const knownSkills = new Set(allDocs.map(doc => doc.split('\n')[0]));
-        const missingSkills = skills.filter(skill => !knownSkills.has(skill));
+        const missingSkills = usedSkills.filter(skill => !knownSkills.has(skill));
         if (missingSkills.length > 0) {
             result += 'These functions do not exist:\n';
             result += missingSkills.join('\n');
@@ -149,14 +145,14 @@ export class Coder {
             });
             result += 'The code contains exceptions and cannot continue execution.';
         } else {
-            return null;//no error
+            return null;
         }
 
-        return result ;
+        return result;
     }
-    // write custom code to file and import it
-    // write custom code to file and prepare for evaluation
+
     async _stageCode(code) {
+        await this.ready;
         code = this._sanitizeCode(code);
         let src = '';
         code = code.replaceAll('console.log(', 'log(bot,');
@@ -164,7 +160,6 @@ export class Coder {
 
         console.log(`Generated code: """${code}"""`);
 
-        // this may cause problems in callback functions
         code = code.replaceAll(';\n', '; if(bot.interrupt_code) {log(bot, "Code interrupted.");return;}\n');
         for (let line of code.split('\n')) {
             src += `    ${line}\n`;
@@ -173,19 +168,9 @@ export class Coder {
         src = this.code_template.replace('/* CODE HERE */', src);
 
         let filename = this.file_counter + '.js';
-        // if (this.file_counter > 0) {
-        //     let prev_filename = this.fp + (this.file_counter-1) + '.js';
-        //     unlink(prev_filename, (err) => {
-        //         console.log("deleted file " + prev_filename);
-        //         if (err) console.error(err);
-        //     });
-        // } commented for now, useful to keep files for debugging
         this.file_counter++;
         
         let write_result = await this._writeFilePromise('.' + this.fp + filename, src);
-        // This is where we determine the environment the agent's code should be exposed to.
-        // It will only have access to these things, (in addition to basic javascript objects like Array, Object, etc.)
-        // Note that the code may be able to modify the exposed objects.
         const compartment = makeCompartment({
             skills,
             log: skills.log,
@@ -214,7 +199,6 @@ export class Coder {
     }
 
     _writeFilePromise(filename, src) {
-        // makes it so we can await this function
         return new Promise((resolve, reject) => {
             writeFile(filename, src, (err) => {
                 if (err) {

--- a/src/agent/coder.js
+++ b/src/agent/coder.js
@@ -17,8 +17,7 @@ export class Coder {
         this.fp = '/bots/'+agent.name+'/action-code/';
         this.code_template = '';
         this.code_lint_template = '';
-
-        this.ready = this._loadTemplates();
+        this.ready = null;
         mkdirSync('.' + this.fp, { recursive: true });
     }
 
@@ -29,8 +28,14 @@ export class Coder {
         ]);
     }
 
-    async generateCode(agent_history) {
+    async _ensureReady() {
+        if (!this.ready)
+            this.ready = this._loadTemplates();
         await this.ready;
+    }
+
+    async generateCode(agent_history) {
+        await this._ensureReady();
         this.agent.bot.modes.pause('unstuck');
         lockdown();
         let messages = agent_history.getHistory(); 
@@ -152,7 +157,7 @@ export class Coder {
     }
 
     async _stageCode(code) {
-        await this.ready;
+        await this._ensureReady();
         code = this._sanitizeCode(code);
         let src = '';
         code = code.replaceAll('console.log(', 'log(bot,');

--- a/src/agent/coder.js
+++ b/src/agent/coder.js
@@ -44,7 +44,6 @@ export class Coder {
         const MAX_ATTEMPTS = 5;
         const MAX_NO_CODE = 3;
 
-        let code = null;
         let no_code_failures = 0;
         for (let i=0; i<MAX_ATTEMPTS; i++) {
             if (this.agent.bot.interrupt_code)
@@ -74,7 +73,7 @@ export class Coder {
                 no_code_failures++;
                 continue;
             }
-            code = res.substring(res.indexOf('```')+3, res.lastIndexOf('```'));
+            const code = res.substring(res.indexOf('```')+3, res.lastIndexOf('```'));
             const result = await this._stageCode(code);
             const executionModule = result.func;
             const lintResult = await this._lintCode(result.src_lint_copy);

--- a/tests/coder_initialization.test.js
+++ b/tests/coder_initialization.test.js
@@ -1,0 +1,16 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { Coder } from '../src/agent/coder.js';
+
+test('coder readiness loads both generated-code templates before use', async () => {
+    const coder = Object.create(Coder.prototype);
+    coder.code_template = '';
+    coder.code_lint_template = '';
+    coder.ready = null;
+
+    await Promise.all([coder._ensureReady(), coder._ensureReady()]);
+
+    assert.match(coder.code_template, /\/\* CODE HERE \*\//);
+    assert.match(coder.code_lint_template, /\/\* CODE HERE \*\//);
+    assert.ok(coder.ready instanceof Promise);
+});


### PR DESCRIPTION
## Merge status

**BLOCKED BY:** None

This PR has no known dependency on another PR in the #59-#90 series.

## Summary
Remove the asynchronous constructor race in `Coder` template loading.

## Why
The constructor starts two callback-based reads but code generation can begin before either template has loaded, leaving empty templates and invalid staged code.

## Changes
- Load both templates through one initialization promise.
- Await template readiness before generation/staging.
- Rename the local skill collection to avoid shadowing the imported `skills` module.

## Scope
Generated-code initialization only.