### PR TITLE
Use bounded concurrency for Minecraft LAN server discovery

### DIFF
--- a/src/mindcraft/mcserver.js
+++ b/src/mindcraft/mcserver.js
@@ -9,7 +9,7 @@ import mc from 'minecraft-protocol';
  * @param {boolean} verbose - Whether to print output on connection errors.
  * @returns {Promise<Object|null>}
  */
-export async function serverInfo(ip, port, timeout = 1000, verbose = false) {
+export function serverInfo(ip, port, timeout = 1000, verbose = false) {
     return new Promise((resolve) => {
         let settled = false;
         const finish = (value) => {
@@ -145,8 +145,6 @@ export async function findServers(ip, earlyExit = false, timeout = 100, options 
  */
 export async function getServer(host, port, version) {
     let server = null;
-    let serverString = '';
-    let serverVersion = '';
 
     if (port == -1) {
         console.log(`No port provided. Searching for LAN server on host ${host}...`);
@@ -164,12 +162,8 @@ export async function getServer(host, port, version) {
     if (server == null)
         throw new Error(`MC server not found. (Host: ${host}, Port: ${port}) Check the host and port in settings.js, and ensure the server is running and open to public or LAN.`);
 
-    serverString = `(Host: ${server.host}, Port: ${server.port}, Version: ${server.version})`;
-
-    if (version === 'auto')
-        serverVersion = server.version;
-    else
-        serverVersion = version;
+    const serverString = `(Host: ${server.host}, Port: ${server.port}, Version: ${server.version})`;
+    const serverVersion = version === 'auto' ? server.version : version;
 
     if (!serverVersion) {
         throw new Error(`MC server was found ${serverString}, but its Minecraft version could not be determined.`);

--- a/src/mindcraft/mcserver.js
+++ b/src/mindcraft/mcserver.js
@@ -2,103 +2,119 @@ import net from 'net';
 import mc from 'minecraft-protocol';
 
 /**
- * Scans the IP address for Minecraft LAN servers and collects their info.
+ * Pings a Minecraft server and returns its advertised metadata.
  * @param {string} ip - The IP address to scan.
  * @param {number} port - The port to check.
  * @param {number} timeout - The connection timeout in ms.
  * @param {boolean} verbose - Whether to print output on connection errors.
- * @returns {Promise<Array>} - A Promise that resolves to an array of server info objects.
+ * @returns {Promise<Object|null>}
  */
 export async function serverInfo(ip, port, timeout = 1000, verbose = false) {
     return new Promise((resolve) => {
+        let settled = false;
+        const finish = (value) => {
+            if (settled) return;
+            settled = true;
+            clearTimeout(timeoutId);
+            resolve(value);
+        };
 
-        let timeoutId = setTimeout(() => {
+        const timeoutId = setTimeout(() => {
             if (verbose)
                 console.error(`Timeout pinging server ${ip}:${port}`);
-            resolve(null); // Resolve as null if no response within timeout
+            finish(null);
         }, timeout);
 
         mc.ping({
             host: ip,
             port
         }, (err, response) => {
-            clearTimeout(timeoutId);
-
             if (err) {
                 if (verbose)
                     console.error(`Error pinging server ${ip}:${port}`, err);
-                return resolve(null);
+                return finish(null);
             }
 
-            // extract version number from modded servers like "Paper 1.21.4"
             const version = response?.version?.name || '';
             const match = String(version).match(/\d+\.\d+(?:\.\d+)?/);
             const numericVersion = match ? match[0] : null;
-            if (numericVersion !== version) {
+            if (verbose && numericVersion !== version) {
                 console.log(`Modded server found (${version}), attempting to use ${numericVersion}...`);
             }
 
-            const serverInfo = {
+            const description = response?.description;
+            const name = typeof description === 'string'
+                ? description
+                : description?.text || 'No description provided.';
+
+            finish({
                 host: ip,
                 port,
-                name: response.description.text || 'No description provided.',
-                ping: response.latency,
+                name,
+                ping: response?.latency,
                 version: numericVersion
-            };
-
-            resolve(serverInfo);
+            });
         });
     });
 }
 
+function checkPort(ip, port, timeout) {
+    return new Promise((resolve) => {
+        const socket = net.createConnection({ host: ip, port, timeout });
+        let settled = false;
+
+        const finish = (value) => {
+            if (settled) return;
+            settled = true;
+            socket.destroy();
+            resolve(value);
+        };
+
+        socket.once('connect', () => finish(port));
+        socket.once('error', () => finish(null));
+        socket.once('timeout', () => finish(null));
+    });
+}
+
 /**
- * Scans the IP address for Minecraft LAN servers and collects their info.
+ * Scans the normal Minecraft LAN port range using bounded concurrency.
  * @param {string} ip - The IP address to scan.
- * @param {boolean} earlyExit - Whether to exit early after finding a server.
- * @param {number} timeout - The connection timeout in ms.
- * @returns {Promise<Array>} - A Promise that resolves to an array of server info objects.
+ * @param {boolean} earlyExit - Whether to stop once a server is found.
+ * @param {number} timeout - Per-port TCP timeout in ms.
+ * @returns {Promise<Array>}
  */
 export async function findServers(ip, earlyExit = false, timeout = 100) {
     const servers = [];
     const startPort = 49000;
     const endPort = 65000;
+    const concurrency = 64;
+    let nextPort = startPort;
+    let stop = false;
 
-    const checkPort = (port) => {
-        return new Promise((resolve) => {
-            const socket = net.createConnection({ host: ip, port, timeout }, () => {
-                socket.end();
-                resolve(port); // Port is open
-            });
+    async function worker() {
+        while (!stop) {
+            const port = nextPort++;
+            if (port > endPort) return;
 
-            socket.on('error', () => resolve(null)); // Port is closed
-            socket.on('timeout', () => {
-                socket.destroy();
-                resolve(null);
-            });
-        });
-    };
+            const openPort = await checkPort(ip, port, timeout);
+            if (!openPort || stop) continue;
 
-    // This supresses a lot of annoying console output from the mc library
-    // TODO: find a better way to do this, it supresses other useful output
-    const originalConsoleLog = console.log;
-    console.log = () => { };
-    
-    for (let port = startPort; port <= endPort; port++) {
-        const openPort = await checkPort(port);
-        if (openPort) {
-            const server = await serverInfo(ip, port, 200, false);
-            if (server) {
-                servers.push(server);
+            const server = await serverInfo(ip, openPort, 200, false);
+            if (!server || stop) continue;
 
-                if (earlyExit) break;
+            servers.push(server);
+            if (earlyExit) {
+                stop = true;
+                return;
             }
         }
     }
 
-    // Restore console output
-    console.log = originalConsoleLog;
+    const workerCount = Math.min(concurrency, endPort - startPort + 1);
+    await Promise.all(Array.from({ length: workerCount }, () => worker()));
+    servers.sort((a, b) => a.port - b.port);
 
-    return servers;
+    return earlyExit ? servers.slice(0, 1) : servers;
 }
 
 /**
@@ -110,42 +126,43 @@ export async function findServers(ip, earlyExit = false, timeout = 100) {
  */
 export async function getServer(host, port, version) {
     let server = null;
-    let serverString = "";
-    let serverVersion = "";
-    
-    // Search for server
-    if (port == -1)
-    {
+    let serverString = '';
+    let serverVersion = '';
+
+    if (port == -1) {
         console.log(`No port provided. Searching for LAN server on host ${host}...`);
-        
-        await findServers(host, true).then((servers) => {
-            if (servers.length > 0)
-                server = servers[0];
-        });
+        const servers = await findServers(host, true);
+        if (servers.length > 0)
+            server = servers[0];
 
         if (server == null)
-            throw new Error(`No server found on LAN.`);
+            throw new Error('No server found on LAN.');
     }
-    else
+    else {
         server = await serverInfo(host, port, 1000, true);
+    }
 
-    // Server not found
-    if (server == null) 
+    if (server == null)
         throw new Error(`MC server not found. (Host: ${host}, Port: ${port}) Check the host and port in settings.js, and ensure the server is running and open to public or LAN.`);
 
     serverString = `(Host: ${server.host}, Port: ${server.port}, Version: ${server.version})`;
 
-    if (version === "auto") 
+    if (version === 'auto')
         serverVersion = server.version;
     else
         serverVersion = version;
-    // Server version unsupported / mismatch
-    const isSupported = mc.supportedVersions.some(v => 
+
+    if (!serverVersion) {
+        throw new Error(`MC server was found ${serverString}, but its Minecraft version could not be determined.`);
+    }
+
+    const isSupported = mc.supportedVersions.some(v =>
         serverVersion === v || (serverVersion.startsWith(v) && serverVersion.charAt(v.length) === '.')
-    ); // Checks version or parent version (e.g. if 1.7 is supported then 1.7.2 will be allowed)
-     if (!isSupported)
-        throw new Error(`MC server was found ${serverString}, but version is unsupported. Supported versions are: ${mc.supportedVersions.join(", ")}.`);
-    else if (version !== "auto" && server.version !== version)
+    );
+
+    if (!isSupported)
+        throw new Error(`MC server was found ${serverString}, but version is unsupported. Supported versions are: ${mc.supportedVersions.join(', ')}.`);
+    else if (version !== 'auto' && server.version !== version)
         throw new Error(`MC server was found ${serverString}, but version is incorrect. Expected ${version}, but found ${server.version}. Check the server version in settings.js.`);
     else
         console.log(`MC server found. ${serverString}`);

--- a/src/mindcraft/mcserver.js
+++ b/src/mindcraft/mcserver.js
@@ -76,18 +76,37 @@ function checkPort(ip, port, timeout) {
     });
 }
 
+export function resolveScanOptions(options = {}) {
+    const startPort = options.startPort ?? 49000;
+    const endPort = options.endPort ?? 65000;
+    const concurrency = options.concurrency ?? 64;
+    const pingTimeout = options.pingTimeout ?? 200;
+
+    for (const [name, value] of Object.entries({ startPort, endPort, concurrency, pingTimeout })) {
+        if (!Number.isInteger(value))
+            throw new Error(`${name} must be an integer.`);
+    }
+    if (startPort < 1 || endPort > 65535 || startPort > endPort)
+        throw new Error('Scan port range must be within 1..65535 and startPort must not exceed endPort.');
+    if (concurrency < 1 || concurrency > 512)
+        throw new Error('concurrency must be between 1 and 512.');
+    if (pingTimeout < 1)
+        throw new Error('pingTimeout must be positive.');
+
+    return { startPort, endPort, concurrency, pingTimeout };
+}
+
 /**
  * Scans the normal Minecraft LAN port range using bounded concurrency.
  * @param {string} ip - The IP address to scan.
  * @param {boolean} earlyExit - Whether to stop once a server is found.
  * @param {number} timeout - Per-port TCP timeout in ms.
+ * @param {Object} options - Optional scan range/concurrency/ping timeout overrides.
  * @returns {Promise<Array>}
  */
-export async function findServers(ip, earlyExit = false, timeout = 100) {
+export async function findServers(ip, earlyExit = false, timeout = 100, options = {}) {
     const servers = [];
-    const startPort = 49000;
-    const endPort = 65000;
-    const concurrency = 64;
+    const { startPort, endPort, concurrency, pingTimeout } = resolveScanOptions(options);
     let nextPort = startPort;
     let stop = false;
 
@@ -99,7 +118,7 @@ export async function findServers(ip, earlyExit = false, timeout = 100) {
             const openPort = await checkPort(ip, port, timeout);
             if (!openPort || stop) continue;
 
-            const server = await serverInfo(ip, openPort, 200, false);
+            const server = await serverInfo(ip, openPort, pingTimeout, false);
             if (!server || stop) continue;
 
             servers.push(server);

--- a/tests/mcserver_scan_options.test.js
+++ b/tests/mcserver_scan_options.test.js
@@ -1,0 +1,25 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { resolveScanOptions } from '../src/mindcraft/mcserver.js';
+
+test('LAN scan options expose safe defaults and allow bounded overrides', () => {
+    assert.deepEqual(resolveScanOptions(), {
+        startPort: 49000,
+        endPort: 65000,
+        concurrency: 64,
+        pingTimeout: 200,
+    });
+    assert.deepEqual(resolveScanOptions({ startPort: 50000, endPort: 50010, concurrency: 4, pingTimeout: 500 }), {
+        startPort: 50000,
+        endPort: 50010,
+        concurrency: 4,
+        pingTimeout: 500,
+    });
+});
+
+test('LAN scan options reject invalid bounds', () => {
+    assert.throws(() => resolveScanOptions({ startPort: 0 }), /port range/);
+    assert.throws(() => resolveScanOptions({ startPort: 60000, endPort: 50000 }), /port range/);
+    assert.throws(() => resolveScanOptions({ concurrency: 0 }), /concurrency/);
+    assert.throws(() => resolveScanOptions({ pingTimeout: 0 }), /pingTimeout/);
+});


### PR DESCRIPTION
## Merge status

**BLOCKED BY:** None

This PR has no known dependency on another PR in the #59-#90 series.

## Summary
Replace the sequential LAN-port scan with bounded concurrent probing and harden Minecraft server metadata parsing.

## Why
Scanning the full LAN port range one port at a time can take a long time. The existing implementation also temporarily suppresses global `console.log`.

## Changes
- Probe ports with bounded worker concurrency.
- Stop early once a server is found when requested.
- Avoid mutating global console behavior.
- Ensure socket and ping paths settle only once.
- Harden server description/version parsing.

## Scope
Minecraft LAN discovery only.