### PR TITLE
Fix self-prompter stop, pause, and restart races

### DIFF
--- a/src/agent/self_prompter.js
+++ b/src/agent/self_prompter.js
@@ -1,11 +1,13 @@
 const STOPPED = 0
 const ACTIVE = 1
 const PAUSED = 2
+
 export class SelfPrompter {
     constructor(agent) {
         this.agent = agent;
         this.state = STOPPED;
         this.loop_active = false;
+        this.loopPromise = null;
         this.interrupt = false;
         this.prompt = '';
         this.idle_time = 0;
@@ -21,9 +23,9 @@ export class SelfPrompter {
         }
         this.state = ACTIVE;
         this.prompt = prompt;
-        if (!this.loop_active)
+        if (!this.loopPromise)
             this.interrupt = false;
-        this.startLoop();
+        void this.startLoop();
     }
 
     isActive() {
@@ -55,18 +57,12 @@ export class SelfPrompter {
         this.state = PAUSED;
     }
 
-    async startLoop() {
-        if (this.loop_active) {
-            console.warn('Self-prompt loop is already active. Ignoring request.');
-            return;
-        }
-        console.log('starting self-prompt loop')
-        this.loop_active = true;
+    async _runLoop() {
         let no_command_count = 0;
         const MAX_NO_COMMAND = 3;
         while (!this.interrupt) {
             const msg = `You are self-prompting with the goal: '${this.prompt}'. Your next response MUST contain a command with this syntax: !commandName. Respond:`;
-            
+
             let used_command = await this.agent.handleMessage('system', msg, -1);
             if (!used_command) {
                 no_command_count++;
@@ -83,8 +79,27 @@ export class SelfPrompter {
                 await new Promise(r => setTimeout(r, this.cooldown));
             }
         }
-        console.log('self prompt loop stopped')
-        this.loop_active = false;
+    }
+
+    async startLoop() {
+        if (this.loopPromise) {
+            console.warn('Self-prompt loop is already active. Ignoring request.');
+            return this.loopPromise;
+        }
+
+        console.log('starting self-prompt loop');
+        this.loop_active = true;
+        const loopPromise = this._runLoop();
+        this.loopPromise = loopPromise;
+
+        try {
+            await loopPromise;
+        } finally {
+            console.log('self prompt loop stopped');
+            this.loop_active = false;
+            if (this.loopPromise === loopPromise)
+                this.loopPromise = null;
+        }
     }
 
     update(delta) {
@@ -96,7 +111,7 @@ export class SelfPrompter {
 
             if (this.idle_time >= this.cooldown) {
                 console.log('Restarting self-prompting...');
-                this.startLoop();
+                void this.startLoop();
                 this.idle_time = 0;
             }
         }
@@ -106,12 +121,14 @@ export class SelfPrompter {
     }
 
     async stopLoop() {
-        if (this.loop_active)
-            console.log('stopping self-prompt loop')
+        if (this.loopPromise)
+            console.log('stopping self-prompt loop');
         this.interrupt = true;
-        while (this.loop_active) {
-            await new Promise(r => setTimeout(r, 100));
-        }
+
+        const activeLoop = this.loopPromise;
+        if (activeLoop)
+            await activeLoop;
+
         this.interrupt = false;
     }
 

--- a/src/agent/self_prompter.js
+++ b/src/agent/self_prompter.js
@@ -21,6 +21,8 @@ export class SelfPrompter {
         }
         this.state = ACTIVE;
         this.prompt = prompt;
+        if (!this.loop_active)
+            this.interrupt = false;
         this.startLoop();
     }
 
@@ -44,7 +46,7 @@ export class SelfPrompter {
         if (state !== STOPPED && !prompt)
             throw new Error('No prompt loaded when self-prompting is active');
         if (state === ACTIVE) {
-            await this.start(prompt);
+            this.start(prompt);
         }
     }
 
@@ -83,11 +85,9 @@ export class SelfPrompter {
         }
         console.log('self prompt loop stopped')
         this.loop_active = false;
-        this.interrupt = false;
     }
 
     update(delta) {
-        // automatically restarts loop
         if (this.state === ACTIVE && !this.loop_active && !this.interrupt) {
             if (this.agent.isIdle())
                 this.idle_time += delta;
@@ -106,41 +106,37 @@ export class SelfPrompter {
     }
 
     async stopLoop() {
-        // you can call this without await if you don't need to wait for it to finish
-        if (this.interrupt)
-            return;
-        console.log('stopping self-prompt loop')
+        if (this.loop_active)
+            console.log('stopping self-prompt loop')
         this.interrupt = true;
         while (this.loop_active) {
-            await new Promise(r => setTimeout(r, 500));
+            await new Promise(r => setTimeout(r, 100));
         }
         this.interrupt = false;
     }
 
     async stop(stop_action=true) {
+        this.state = STOPPED;
         this.interrupt = true;
         if (stop_action)
             await this.agent.actions.stop();
-        this.stopLoop();
-        this.state = STOPPED;
+        await this.stopLoop();
     }
 
     async pause() {
+        this.state = PAUSED;
         this.interrupt = true;
         await this.agent.actions.stop();
-        this.stopLoop();
-        this.state = PAUSED;
+        await this.stopLoop();
     }
 
-    shouldInterrupt(is_self_prompt) { // to be called from handleMessage
+    shouldInterrupt(is_self_prompt) {
         return is_self_prompt && (this.state === ACTIVE || this.state === PAUSED) && this.interrupt;
     }
 
     handleUserPromptedCmd(is_self_prompt, is_action) {
-        // if a user messages and the bot responds with an action, stop the self-prompt loop
         if (!is_self_prompt && is_action) {
-            this.stopLoop();
-            // this stops it from responding from the handlemessage loop and the self-prompt loop at the same time
+            void this.stopLoop();
         }
     }
 }

--- a/src/agent/self_prompter.js
+++ b/src/agent/self_prompter.js
@@ -1,6 +1,6 @@
-const STOPPED = 0
-const ACTIVE = 1
-const PAUSED = 2
+const STOPPED = 0;
+const ACTIVE = 1;
+const PAUSED = 2;
 
 export class SelfPrompter {
     constructor(agent) {

--- a/src/agent/self_prompter.js
+++ b/src/agent/self_prompter.js
@@ -8,6 +8,7 @@ export class SelfPrompter {
         this.state = STOPPED;
         this.loop_active = false;
         this.loopPromise = null;
+        this.restartAfterStop = false;
         this.interrupt = false;
         this.prompt = '';
         this.idle_time = 0;
@@ -23,8 +24,15 @@ export class SelfPrompter {
         }
         this.state = ACTIVE;
         this.prompt = prompt;
-        if (!this.loopPromise)
-            this.interrupt = false;
+
+        if (this.loopPromise) {
+            // A newer start request wins over an in-flight stop/pause. Let the
+            // owned loop unwind first, then start a fresh loop exactly once.
+            this.restartAfterStop = true;
+            return;
+        }
+
+        this.interrupt = false;
         void this.startLoop();
     }
 
@@ -96,12 +104,20 @@ export class SelfPrompter {
             await loopPromise;
         } catch (error) {
             this.state = STOPPED;
+            this.restartAfterStop = false;
             console.error('Self-prompt loop failed:', error);
         } finally {
             console.log('self prompt loop stopped');
             this.loop_active = false;
             if (this.loopPromise === loopPromise)
                 this.loopPromise = null;
+
+            const shouldRestart = this.restartAfterStop && this.state === ACTIVE;
+            this.restartAfterStop = false;
+            if (shouldRestart) {
+                this.interrupt = false;
+                void this.startLoop();
+            }
         }
     }
 
@@ -137,6 +153,7 @@ export class SelfPrompter {
 
     async stop(stop_action=true) {
         this.state = STOPPED;
+        this.restartAfterStop = false;
         this.interrupt = true;
         if (stop_action)
             await this.agent.actions.stop();
@@ -145,6 +162,7 @@ export class SelfPrompter {
 
     async pause() {
         this.state = PAUSED;
+        this.restartAfterStop = false;
         this.interrupt = true;
         await this.agent.actions.stop();
         await this.stopLoop();

--- a/src/agent/self_prompter.js
+++ b/src/agent/self_prompter.js
@@ -40,7 +40,7 @@ export class SelfPrompter {
         return this.state === PAUSED;
     }
 
-    async handleLoad(prompt, state) {
+    handleLoad(prompt, state) {
         if (state == undefined)
             state = STOPPED;
         this.state = state;

--- a/src/agent/self_prompter.js
+++ b/src/agent/self_prompter.js
@@ -94,6 +94,9 @@ export class SelfPrompter {
 
         try {
             await loopPromise;
+        } catch (error) {
+            this.state = STOPPED;
+            console.error('Self-prompt loop failed:', error);
         } finally {
             console.log('self prompt loop stopped');
             this.loop_active = false;

--- a/tests/self_prompter.test.js
+++ b/tests/self_prompter.test.js
@@ -51,3 +51,15 @@ test('stop changes state immediately and waits for loop shutdown', async () => {
     assert.equal(prompter.loop_active, false);
     assert.equal(prompter.interrupt, false);
 });
+
+test('loop failures are contained and transition self-prompting to stopped', async () => {
+    const prompter = makePrompter({
+        handleMessage: async () => { throw new Error('boom'); },
+    });
+
+    await prompter.startLoop();
+
+    assert.equal(prompter.isStopped(), true);
+    assert.equal(prompter.loop_active, false);
+    assert.equal(prompter.loopPromise, null);
+});

--- a/tests/self_prompter.test.js
+++ b/tests/self_prompter.test.js
@@ -52,6 +52,43 @@ test('stop changes state immediately and waits for loop shutdown', async () => {
     assert.equal(prompter.interrupt, false);
 });
 
+test('a start request racing shutdown restarts with the latest prompt', async () => {
+    let firstRelease;
+    let secondRelease;
+    let calls = 0;
+    const prompter = makePrompter({
+        handleMessage: () => new Promise(resolve => {
+            calls++;
+            if (calls === 1)
+                firstRelease = () => resolve(true);
+            else
+                secondRelease = () => resolve(true);
+        }),
+    });
+    prompter.cooldown = 0;
+    prompter.start('first goal');
+    await new Promise(resolve => setImmediate(resolve));
+
+    const stopping = prompter.stopLoop();
+    prompter.start('replacement goal');
+    firstRelease();
+    await stopping;
+
+    for (let i = 0; i < 5 && !secondRelease; i++)
+        await new Promise(resolve => setImmediate(resolve));
+
+    assert.equal(prompter.isActive(), true);
+    assert.equal(prompter.prompt, 'replacement goal');
+    assert.equal(prompter.loop_active, true);
+    assert.equal(calls, 2);
+
+    const finalStop = prompter.stop(false);
+    secondRelease();
+    await finalStop;
+    assert.equal(prompter.isStopped(), true);
+    assert.equal(prompter.loop_active, false);
+});
+
 test('loop failures are contained and transition self-prompting to stopped', async () => {
     const prompter = makePrompter({
         handleMessage: () => Promise.reject(new Error('boom')),

--- a/tests/self_prompter.test.js
+++ b/tests/self_prompter.test.js
@@ -4,9 +4,9 @@ import { SelfPrompter } from '../src/agent/self_prompter.js';
 
 function makePrompter(overrides = {}) {
     const agent = {
-        actions: { stop: async () => {} },
+        actions: { stop: () => Promise.resolve() },
         isIdle: () => true,
-        handleMessage: async () => true,
+        handleMessage: () => Promise.resolve(true),
         openChat: () => {},
         ...overrides,
     };
@@ -54,7 +54,7 @@ test('stop changes state immediately and waits for loop shutdown', async () => {
 
 test('loop failures are contained and transition self-prompting to stopped', async () => {
     const prompter = makePrompter({
-        handleMessage: async () => { throw new Error('boom'); },
+        handleMessage: () => Promise.reject(new Error('boom')),
     });
 
     await prompter.startLoop();

--- a/tests/self_prompter.test.js
+++ b/tests/self_prompter.test.js
@@ -1,0 +1,37 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { SelfPrompter } from '../src/agent/self_prompter.js';
+
+function makePrompter() {
+    const agent = {
+        actions: { stop: async () => {} },
+        isIdle: () => true,
+        handleMessage: async () => true,
+        openChat: () => {},
+    };
+    return new SelfPrompter(agent);
+}
+
+test('stopLoop waits even when interrupt was already requested', async () => {
+    const prompter = makePrompter();
+    prompter.loop_active = true;
+    prompter.interrupt = true;
+    setTimeout(() => { prompter.loop_active = false; }, 20);
+
+    await prompter.stopLoop();
+
+    assert.equal(prompter.loop_active, false);
+    assert.equal(prompter.interrupt, false);
+});
+
+test('stop changes state immediately and clears the interrupt after shutdown', async () => {
+    const prompter = makePrompter();
+    prompter.state = 1;
+    prompter.loop_active = true;
+    setTimeout(() => { prompter.loop_active = false; }, 20);
+
+    const stopping = prompter.stop(false);
+    assert.equal(prompter.isStopped(), true);
+    await stopping;
+    assert.equal(prompter.interrupt, false);
+});

--- a/tests/self_prompter.test.js
+++ b/tests/self_prompter.test.js
@@ -2,36 +2,52 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { SelfPrompter } from '../src/agent/self_prompter.js';
 
-function makePrompter() {
+function makePrompter(overrides = {}) {
     const agent = {
         actions: { stop: async () => {} },
         isIdle: () => true,
         handleMessage: async () => true,
         openChat: () => {},
+        ...overrides,
     };
     return new SelfPrompter(agent);
 }
 
-test('stopLoop waits even when interrupt was already requested', async () => {
-    const prompter = makePrompter();
-    prompter.loop_active = true;
-    prompter.interrupt = true;
-    setTimeout(() => { prompter.loop_active = false; }, 20);
+test('stopLoop waits for the owned loop promise and clears lifecycle state', async () => {
+    let release;
+    const prompter = makePrompter({
+        handleMessage: () => new Promise(resolve => { release = () => resolve(true); }),
+    });
+    prompter.cooldown = 0;
+    prompter.start('test goal');
 
-    await prompter.stopLoop();
+    await new Promise(resolve => setImmediate(resolve));
+    assert.equal(prompter.loop_active, true);
+    assert.ok(prompter.loopPromise);
+
+    const stopping = prompter.stopLoop();
+    release();
+    await stopping;
 
     assert.equal(prompter.loop_active, false);
+    assert.equal(prompter.loopPromise, null);
     assert.equal(prompter.interrupt, false);
 });
 
-test('stop changes state immediately and clears the interrupt after shutdown', async () => {
-    const prompter = makePrompter();
-    prompter.state = 1;
-    prompter.loop_active = true;
-    setTimeout(() => { prompter.loop_active = false; }, 20);
+test('stop changes state immediately and waits for loop shutdown', async () => {
+    let release;
+    const prompter = makePrompter({
+        handleMessage: () => new Promise(resolve => { release = () => resolve(true); }),
+    });
+    prompter.cooldown = 0;
+    prompter.start('test goal');
+    await new Promise(resolve => setImmediate(resolve));
 
     const stopping = prompter.stop(false);
     assert.equal(prompter.isStopped(), true);
+    release();
     await stopping;
+
+    assert.equal(prompter.loop_active, false);
     assert.equal(prompter.interrupt, false);
 });


### PR DESCRIPTION
## Merge status

**BLOCKED BY:** None

This PR has no known dependency on another PR in the #59-#90 series.

## Summary
Make self-prompter lifecycle transitions wait for the active loop to unwind cleanly and avoid stale interrupt state.

## Why
Concurrent stop/pause requests can return before the loop has actually stopped, while a subsequent start can inherit an interrupt flag from the prior lifecycle.

## Changes
- Make `stopLoop()` wait even when interruption was already requested.
- Set stopped/paused state before asynchronous shutdown work.
- Await loop shutdown from stop/pause.
- Clear stale interrupts before a fresh start.
- Add lifecycle regression tests.

## Scope
Self-prompt lifecycle/state management only.