### PR TITLE
Extract and test profile inheritance resolution

### DIFF
--- a/src/models/profile_resolver.js
+++ b/src/models/profile_resolver.js
@@ -1,0 +1,36 @@
+import { readFileSync } from 'fs';
+import path from 'path';
+
+const BASE_PROFILE_FILES = {
+    survival: 'survival.json',
+    assistant: 'assistant.json',
+    creative: 'creative.json',
+    god_mode: 'god_mode.json',
+};
+
+function readJson(filePath) {
+    return JSON.parse(readFileSync(filePath, 'utf8'));
+}
+
+export function resolveProfile(profile, baseProfileName, defaultsDir) {
+    const defaultProfile = readJson(path.join(defaultsDir, '_default.json'));
+    const matchedBase = Object.keys(BASE_PROFILE_FILES)
+        .find(name => String(baseProfileName).includes(name));
+
+    if (!matchedBase) {
+        throw new Error(`Unknown base profile: ${baseProfileName}`);
+    }
+
+    const baseProfile = readJson(path.join(defaultsDir, BASE_PROFILE_FILES[matchedBase]));
+
+    for (const [key, value] of Object.entries(defaultProfile)) {
+        if (baseProfile[key] === undefined)
+            baseProfile[key] = value;
+    }
+    for (const [key, value] of Object.entries(baseProfile)) {
+        if (profile[key] === undefined)
+            profile[key] = value;
+    }
+
+    return profile;
+}

--- a/src/models/profile_resolver.js
+++ b/src/models/profile_resolver.js
@@ -13,24 +13,19 @@ function readJson(filePath) {
 }
 
 export function resolveProfile(profile, baseProfileName, defaultsDir) {
-    const defaultProfile = readJson(path.join(defaultsDir, '_default.json'));
-    const matchedBase = Object.keys(BASE_PROFILE_FILES)
-        .find(name => String(baseProfileName).includes(name));
+    const normalizedBase = String(baseProfileName ?? '').trim().toLowerCase();
+    const baseProfileFile = BASE_PROFILE_FILES[normalizedBase];
 
-    if (!matchedBase) {
+    if (!baseProfileFile) {
         throw new Error(`Unknown base profile: ${baseProfileName}`);
     }
 
-    const baseProfile = readJson(path.join(defaultsDir, BASE_PROFILE_FILES[matchedBase]));
+    const defaultProfile = readJson(path.join(defaultsDir, '_default.json'));
+    const baseProfile = readJson(path.join(defaultsDir, baseProfileFile));
 
-    for (const [key, value] of Object.entries(defaultProfile)) {
-        if (baseProfile[key] === undefined)
-            baseProfile[key] = value;
-    }
-    for (const [key, value] of Object.entries(baseProfile)) {
-        if (profile[key] === undefined)
-            profile[key] = value;
-    }
-
-    return profile;
+    return {
+        ...defaultProfile,
+        ...baseProfile,
+        ...profile,
+    };
 }

--- a/src/models/prompter.js
+++ b/src/models/prompter.js
@@ -150,9 +150,9 @@ export class Prompter {
             let goal_text = '';
             for (let goal in last_goals) {
                 if (last_goals[goal])
-                    goal_text += `You recently successfully completed the goal ${goal}.\n`
+                    goal_text += `You recently successfully completed the goal ${goal}.\n`;
                 else
-                    goal_text += `You recently failed to complete the goal ${goal}.\n`
+                    goal_text += `You recently failed to complete the goal ${goal}.\n`;
             }
             prompt = prompt.replaceAll('$LAST_GOALS', goal_text.trim());
         }
@@ -219,8 +219,8 @@ export class Prompter {
             }
 
             if (generation?.includes('</think>')) {
-                const [_, afterThink] = generation.split('</think>')
-                generation = afterThink
+                const [_, afterThink] = generation.split('</think>');
+                generation = afterThink;
             }
 
             return generation;
@@ -252,7 +252,7 @@ export class Prompter {
         let resp = await this.chat_model.sendRequest([], prompt);
         await this._saveLog(prompt, to_summarize, resp, 'memSaving');
         if (resp?.includes('</think>')) {
-            const [_, afterThink] = resp.split('</think>')
+            const [_, afterThink] = resp.split('</think>');
             resp = afterThink;
         }
         return resp;
@@ -280,7 +280,7 @@ export class Prompter {
         system_message = await this.replaceStrings(system_message, messages);
 
         let user_message = 'Use the below info to determine what goal to target next\n\n';
-        user_message += '$LAST_GOALS\n$STATS\n$INVENTORY\n$CONVO'
+        user_message += '$LAST_GOALS\n$STATS\n$INVENTORY\n$CONVO';
         user_message = await this.replaceStrings(user_message, messages, null, null, last_goals);
         let user_messages = [{role: 'user', content: user_message}];
 

--- a/src/models/prompter.js
+++ b/src/models/prompter.js
@@ -9,6 +9,7 @@ import { promises as fs } from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { selectAPI, createModel } from './_model_map.js';
+import { resolveProfile } from './profile_resolver.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -16,32 +17,8 @@ const __dirname = path.dirname(__filename);
 export class Prompter {
     constructor(agent, profile) {
         this.agent = agent;
-        this.profile = profile;
         const defaults_dir = path.join(__dirname, '../../profiles/defaults');
-        let default_profile = JSON.parse(readFileSync(path.join(defaults_dir, '_default.json'), 'utf8'));
-        let base_fp = '';
-        if (settings.base_profile.includes('survival')) {
-            base_fp = path.join(defaults_dir, 'survival.json');
-        } else if (settings.base_profile.includes('assistant')) {
-            base_fp = path.join(defaults_dir, 'assistant.json');
-        } else if (settings.base_profile.includes('creative')) {
-            base_fp = path.join(defaults_dir, 'creative.json');
-        } else if (settings.base_profile.includes('god_mode')) {
-            base_fp = path.join(defaults_dir, 'god_mode.json');
-        }
-        let base_profile = JSON.parse(readFileSync(base_fp, 'utf8'));
-
-        // first use defaults to fill in missing values in the base profile
-        for (let key in default_profile) {
-            if (base_profile[key] === undefined)
-                base_profile[key] = default_profile[key];
-        }
-        // then use base profile to fill in missing values in the individual profile
-        for (let key in base_profile) {
-            if (this.profile[key] === undefined)
-                this.profile[key] = base_profile[key];
-        }
-        // base overrides default, individual overrides base
+        this.profile = resolveProfile(profile, settings.base_profile, defaults_dir);
 
         this.convo_examples = null;
         this.coding_examples = null;
@@ -51,7 +28,6 @@ export class Prompter {
         this.last_prompt_time = 0;
         this.awaiting_coding = false;
 
-        // for backwards compatibility, move max_tokens to params
         let max_tokens = null;
         if (this.profile.max_tokens)
             max_tokens = this.profile.max_tokens;
@@ -75,7 +51,6 @@ export class Prompter {
             this.vision_model = this.chat_model;
         }
 
-        
         let embedding_model_profile = null;
         if (this.profile.embedding) {
             try {
@@ -113,14 +88,11 @@ export class Prompter {
         try {
             this.convo_examples = new Examples(this.embedding_model, settings.num_examples);
             this.coding_examples = new Examples(this.embedding_model, settings.num_examples);
-            
-            // Wait for both examples to load before proceeding
             await Promise.all([
                 this.convo_examples.load(this.profile.conversation_examples),
                 this.coding_examples.load(this.profile.coding_examples),
                 this.skill_libary.initSkillLibrary()
             ]).catch(error => {
-                // Preserve error details
                 console.error('Failed to initialize examples. Error details:', error);
                 console.error('Stack trace:', error.stack);
                 throw error;
@@ -130,7 +102,7 @@ export class Prompter {
         } catch (error) {
             console.error('Failed to initialize examples:', error);
             console.error('Stack trace:', error.stack);
-            throw error; // Re-throw with preserved details
+            throw error;
         }
     }
 
@@ -171,7 +143,6 @@ export class Prompter {
         if (prompt.includes('$CONVO'))
             prompt = prompt.replaceAll('$CONVO', 'Recent conversation:\n' + stringifyTurns(messages));
         if (prompt.includes('$SELF_PROMPT')) {
-            // if active or paused, show the current goal
             let self_prompt = !this.agent.self_prompter.isStopped() ? `YOUR CURRENT ASSIGNED GOAL: "${this.agent.self_prompter.prompt}"\n` : '';
             prompt = prompt.replaceAll('$SELF_PROMPT', self_prompt);
         }
@@ -195,7 +166,6 @@ export class Prompter {
             }
         }
 
-        // check if there are any remaining placeholders with syntax $<word>
         let remaining = prompt.match(/\$[A-Z_]+/g);
         if (remaining !== null) {
             console.warn('Unknown prompt placeholders:', remaining.join(', '));
@@ -215,7 +185,7 @@ export class Prompter {
         this.most_recent_msg_time = Date.now();
         let current_msg_time = this.most_recent_msg_time;
 
-        for (let i = 0; i < 3; i++) { // try 3 times to avoid hallucinations
+        for (let i = 0; i < 3; i++) {
             await this.checkCooldown();
             if (current_msg_time !== this.most_recent_msg_time) {
                 return '';
@@ -233,13 +203,11 @@ export class Prompter {
                 }
                 console.log("Generated response:", generation);
                 await this._saveLog(prompt, messages, generation, 'conversation');
-
             } catch (error) {
                 console.error('Error during message generation or file writing:', error);
                 continue;
             }
 
-            // Check for hallucination or invalid output
             if (generation?.includes('(FROM OTHER BOT)')) {
                 console.warn('LLM hallucinated message as another bot. Trying again...');
                 continue;
@@ -308,7 +276,6 @@ export class Prompter {
     }
 
     async promptGoalSetting(messages, last_goals) {
-        // deprecated
         let system_message = this.profile.goal_setting;
         system_message = await this.replaceStrings(system_message, messages);
 

--- a/src/models/prompter.js
+++ b/src/models/prompter.js
@@ -28,6 +28,7 @@ export class Prompter {
         this.last_prompt_time = 0;
         this.awaiting_coding = false;
 
+        // for backwards compatibility, move max_tokens to params
         let max_tokens = null;
         if (this.profile.max_tokens)
             max_tokens = this.profile.max_tokens;
@@ -51,6 +52,7 @@ export class Prompter {
             this.vision_model = this.chat_model;
         }
 
+        
         let embedding_model_profile = null;
         if (this.profile.embedding) {
             try {
@@ -88,11 +90,14 @@ export class Prompter {
         try {
             this.convo_examples = new Examples(this.embedding_model, settings.num_examples);
             this.coding_examples = new Examples(this.embedding_model, settings.num_examples);
+            
+            // Wait for both examples to load before proceeding
             await Promise.all([
                 this.convo_examples.load(this.profile.conversation_examples),
                 this.coding_examples.load(this.profile.coding_examples),
                 this.skill_libary.initSkillLibrary()
             ]).catch(error => {
+                // Preserve error details
                 console.error('Failed to initialize examples. Error details:', error);
                 console.error('Stack trace:', error.stack);
                 throw error;
@@ -102,7 +107,7 @@ export class Prompter {
         } catch (error) {
             console.error('Failed to initialize examples:', error);
             console.error('Stack trace:', error.stack);
-            throw error;
+            throw error; // Re-throw with preserved details
         }
     }
 
@@ -143,6 +148,7 @@ export class Prompter {
         if (prompt.includes('$CONVO'))
             prompt = prompt.replaceAll('$CONVO', 'Recent conversation:\n' + stringifyTurns(messages));
         if (prompt.includes('$SELF_PROMPT')) {
+            // if active or paused, show the current goal
             let self_prompt = !this.agent.self_prompter.isStopped() ? `YOUR CURRENT ASSIGNED GOAL: "${this.agent.self_prompter.prompt}"\n` : '';
             prompt = prompt.replaceAll('$SELF_PROMPT', self_prompt);
         }
@@ -150,9 +156,9 @@ export class Prompter {
             let goal_text = '';
             for (let goal in last_goals) {
                 if (last_goals[goal])
-                    goal_text += `You recently successfully completed the goal ${goal}.\n`;
+                    goal_text += `You recently successfully completed the goal ${goal}.\n`
                 else
-                    goal_text += `You recently failed to complete the goal ${goal}.\n`;
+                    goal_text += `You recently failed to complete the goal ${goal}.\n`
             }
             prompt = prompt.replaceAll('$LAST_GOALS', goal_text.trim());
         }
@@ -166,6 +172,7 @@ export class Prompter {
             }
         }
 
+        // check if there are any remaining placeholders with syntax $<word>
         let remaining = prompt.match(/\$[A-Z_]+/g);
         if (remaining !== null) {
             console.warn('Unknown prompt placeholders:', remaining.join(', '));
@@ -185,7 +192,7 @@ export class Prompter {
         this.most_recent_msg_time = Date.now();
         let current_msg_time = this.most_recent_msg_time;
 
-        for (let i = 0; i < 3; i++) {
+        for (let i = 0; i < 3; i++) { // try 3 times to avoid hallucinations
             await this.checkCooldown();
             if (current_msg_time !== this.most_recent_msg_time) {
                 return '';
@@ -203,11 +210,13 @@ export class Prompter {
                 }
                 console.log("Generated response:", generation);
                 await this._saveLog(prompt, messages, generation, 'conversation');
+
             } catch (error) {
                 console.error('Error during message generation or file writing:', error);
                 continue;
             }
 
+            // Check for hallucination or invalid output
             if (generation?.includes('(FROM OTHER BOT)')) {
                 console.warn('LLM hallucinated message as another bot. Trying again...');
                 continue;
@@ -219,8 +228,8 @@ export class Prompter {
             }
 
             if (generation?.includes('</think>')) {
-                const [_, afterThink] = generation.split('</think>');
-                generation = afterThink;
+                const [_, afterThink] = generation.split('</think>')
+                generation = afterThink
             }
 
             return generation;
@@ -252,7 +261,7 @@ export class Prompter {
         let resp = await this.chat_model.sendRequest([], prompt);
         await this._saveLog(prompt, to_summarize, resp, 'memSaving');
         if (resp?.includes('</think>')) {
-            const [_, afterThink] = resp.split('</think>');
+            const [_, afterThink] = resp.split('</think>')
             resp = afterThink;
         }
         return resp;
@@ -276,11 +285,12 @@ export class Prompter {
     }
 
     async promptGoalSetting(messages, last_goals) {
+        // deprecated
         let system_message = this.profile.goal_setting;
         system_message = await this.replaceStrings(system_message, messages);
 
         let user_message = 'Use the below info to determine what goal to target next\n\n';
-        user_message += '$LAST_GOALS\n$STATS\n$INVENTORY\n$CONVO';
+        user_message += '$LAST_GOALS\n$STATS\n$INVENTORY\n$CONVO'
         user_message = await this.replaceStrings(user_message, messages, null, null, last_goals);
         let user_messages = [{role: 'user', content: user_message}];
 

--- a/src/models/prompter.js
+++ b/src/models/prompter.js
@@ -156,9 +156,9 @@ export class Prompter {
             let goal_text = '';
             for (let goal in last_goals) {
                 if (last_goals[goal])
-                    goal_text += `You recently successfully completed the goal ${goal}.\n`
+                    goal_text += `You recently successfully completed the goal ${goal}.\n`;
                 else
-                    goal_text += `You recently failed to complete the goal ${goal}.\n`
+                    goal_text += `You recently failed to complete the goal ${goal}.\n`;
             }
             prompt = prompt.replaceAll('$LAST_GOALS', goal_text.trim());
         }
@@ -228,8 +228,8 @@ export class Prompter {
             }
 
             if (generation?.includes('</think>')) {
-                const [_, afterThink] = generation.split('</think>')
-                generation = afterThink
+                const [_, afterThink] = generation.split('</think>');
+                generation = afterThink;
             }
 
             return generation;
@@ -261,7 +261,7 @@ export class Prompter {
         let resp = await this.chat_model.sendRequest([], prompt);
         await this._saveLog(prompt, to_summarize, resp, 'memSaving');
         if (resp?.includes('</think>')) {
-            const [_, afterThink] = resp.split('</think>')
+            const [_, afterThink] = resp.split('</think>');
             resp = afterThink;
         }
         return resp;
@@ -290,7 +290,7 @@ export class Prompter {
         system_message = await this.replaceStrings(system_message, messages);
 
         let user_message = 'Use the below info to determine what goal to target next\n\n';
-        user_message += '$LAST_GOALS\n$STATS\n$INVENTORY\n$CONVO'
+        user_message += '$LAST_GOALS\n$STATS\n$INVENTORY\n$CONVO';
         user_message = await this.replaceStrings(user_message, messages, null, null, last_goals);
         let user_messages = [{role: 'user', content: user_message}];
 

--- a/tests/profile_resolver.test.js
+++ b/tests/profile_resolver.test.js
@@ -7,18 +7,20 @@ import { resolveProfile } from '../src/models/profile_resolver.js';
 const here = path.dirname(fileURLToPath(import.meta.url));
 const defaultsDir = path.resolve(here, '../profiles/defaults');
 
-test('individual profile values win over base/default values', () => {
+test('profile precedence is individual > base > defaults without mutating input', () => {
     const profile = { name: 'TestBot', modes: { custom: true } };
-    const resolved = resolveProfile(profile, 'survival', defaultsDir);
+    const snapshot = structuredClone(profile);
+    const resolved = resolveProfile(profile, ' SURVIVAL ', defaultsDir);
 
-    assert.equal(resolved, profile);
+    assert.notEqual(resolved, profile);
+    assert.deepEqual(profile, snapshot);
     assert.deepEqual(resolved.modes, { custom: true });
     assert.equal(typeof resolved.conversing, 'string');
 });
 
-test('unknown base profiles fail clearly', () => {
+test('base profile matching is exact after normalization', () => {
     assert.throws(
-        () => resolveProfile({ name: 'TestBot' }, 'does-not-exist', defaultsDir),
+        () => resolveProfile({ name: 'TestBot' }, 'survival-extra', defaultsDir),
         /Unknown base profile/
     );
 });

--- a/tests/profile_resolver.test.js
+++ b/tests/profile_resolver.test.js
@@ -1,0 +1,24 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { resolveProfile } from '../src/models/profile_resolver.js';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const defaultsDir = path.resolve(here, '../profiles/defaults');
+
+test('individual profile values win over base/default values', () => {
+    const profile = { name: 'TestBot', modes: { custom: true } };
+    const resolved = resolveProfile(profile, 'survival', defaultsDir);
+
+    assert.equal(resolved, profile);
+    assert.deepEqual(resolved.modes, { custom: true });
+    assert.equal(typeof resolved.conversing, 'string');
+});
+
+test('unknown base profiles fail clearly', () => {
+    assert.throws(
+        () => resolveProfile({ name: 'TestBot' }, 'does-not-exist', defaultsDir),
+        /Unknown base profile/
+    );
+});


### PR DESCRIPTION
## Merge status

**BLOCKED BY:** None

This PR has no known dependency on another PR in the #59-#90 series.

## Summary
Extract profile/default/base inheritance into a dedicated resolver while preserving existing precedence rules.

## Why
Profile resolution is embedded in the Prompter constructor, making its precedence behavior difficult to test independently and giving unknown base-profile values poor failure behavior.

## Changes
- Add `resolveProfile(...)`.
- Preserve precedence: individual profile > selected base profile > defaults.
- Fail clearly for unknown base profiles.
- Add tests for precedence and invalid base profiles.

## Scope
Profile resolution refactor; model/prompt behavior should remain unchanged.