### PR TITLE
Serialize bot action ownership with an async mutex

### DIFF
--- a/src/agent/action_manager.js
+++ b/src/agent/action_manager.js
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { AsyncMutex } from '../utils/async_mutex.js';
 
 export class ActionManager {
     constructor(agent) {
@@ -11,31 +12,56 @@ export class ActionManager {
         this.resume_name = '';
         this.last_action_time = 0;
         this.recent_action_counter = 0;
+        this.actionMutex = new AsyncMutex();
+        this.stopPromise = null;
     }
 
     resumeAction(timeout) {
-        return this._executeResume(null, null, timeout);
+        return this.actionMutex.runExclusive(() => this._executeResume(null, null, timeout));
     }
 
     runAction(actionLabel, actionFn, { timeout, resume = false } = {}) {
-        if (resume) {
-            return this._executeResume(actionLabel, actionFn, timeout);
-        } else {
-            return this._executeAction(actionLabel, actionFn, timeout);
+        // Preserve the existing "new action interrupts current action" behavior,
+        // but let the mutex own who is allowed to mutate ActionManager state.
+        if (this.executing) {
+            console.log(`action "${actionLabel}" trying to interrupt current action "${this.currentActionLabel}"`);
+            void this.stop().catch(error => {
+                console.error('Failed to stop current action before queued action:', error);
+            });
         }
+
+        return this.actionMutex.runExclusive(() => {
+            if (resume) {
+                return this._executeResume(actionLabel, actionFn, timeout);
+            }
+            return this._executeAction(actionLabel, actionFn, timeout);
+        });
     }
 
     async stop() {
+        if (this.stopPromise) return this.stopPromise;
         if (!this.executing) return;
-        const timeout = setTimeout(() => {
-            this.agent.cleanKill('Code execution refused stop after 10 seconds. Killing process.');
-        }, 10000);
-        while (this.executing) {
-            this.agent.requestInterrupt();
-            console.log('waiting for code to finish executing...');
-            await new Promise(resolve => setTimeout(resolve, 300));
+
+        this.stopPromise = (async () => {
+            const timeout = setTimeout(() => {
+                this.agent.cleanKill('Code execution refused stop after 10 seconds. Killing process.');
+            }, 10000);
+            try {
+                while (this.executing) {
+                    this.agent.requestInterrupt();
+                    console.log('waiting for code to finish executing...');
+                    await new Promise(resolve => setTimeout(resolve, 300));
+                }
+            } finally {
+                clearTimeout(timeout);
+            }
+        })();
+
+        try {
+            return await this.stopPromise;
+        } finally {
+            this.stopPromise = null;
         }
-        clearTimeout(timeout);
     }
 
     cancelResume() {
@@ -45,19 +71,18 @@ export class ActionManager {
 
     async _executeResume(actionLabel = null, actionFn = null, timeout = 10) {
         const new_resume = actionFn != null;
-        if (new_resume) { // start new resume
+        if (new_resume) {
             this.resume_func = actionFn;
             assert(actionLabel != null, 'actionLabel is required for new resume');
             this.resume_name = actionLabel;
         }
         if (this.resume_func != null && (this.agent.isIdle() || new_resume) && (!this.agent.self_prompter.isActive() || new_resume)) {
             this.currentActionLabel = this.resume_name;
-            let res = await this._executeAction(this.resume_name, this.resume_func, timeout);
+            const res = await this._executeAction(this.resume_name, this.resume_func, timeout);
             this.currentActionLabel = '';
             return res;
-        } else {
-            return { success: false, message: null, interrupted: false, timedout: false };
         }
+        return { success: false, message: null, interrupted: false, timedout: false };
     }
 
     async _executeAction(actionLabel, actionFn, timeout = 10) {
@@ -65,7 +90,7 @@ export class ActionManager {
         this.timedout = false;
         try {
             if (this.last_action_time > 0) {
-                let time_diff = Date.now() - this.last_action_time;
+                const time_diff = Date.now() - this.last_action_time;
                 if (time_diff < 20) {
                     this.recent_action_counter++;
                 }
@@ -74,7 +99,7 @@ export class ActionManager {
                 }
                 if (this.recent_action_counter > 3) {
                     console.warn('Fast action loop detected, cancelling resume.');
-                    this.cancelResume(); // likely cause of repetition
+                    this.cancelResume();
                 }
                 if (this.recent_action_counter > 5) {
                     console.error('Infinite action loop detected, shutting down.');
@@ -85,46 +110,35 @@ export class ActionManager {
             this.last_action_time = Date.now();
             console.log('executing code...\n');
 
-            // await current action to finish (executing=false), with 10 seconds timeout
-            // also tell agent.bot to stop various actions
-            if (this.executing) {
-                console.log(`action "${actionLabel}" trying to interrupt current action "${this.currentActionLabel}"`);
-            }
+            // A previous owner may still be finishing an externally requested stop.
             await this.stop();
 
-            // clear bot logs and reset interrupt code
             this.agent.clearBotLogs();
 
             this.executing = true;
             this.currentActionLabel = actionLabel;
             this.currentActionFn = actionFn;
 
-            // timeout in minutes
             if (timeout > 0) {
                 TIMEOUT = this._startTimeout(timeout);
             }
 
-            // start the action
             await actionFn();
 
-            // mark action as finished + cleanup
             this.executing = false;
             this.currentActionLabel = '';
             this.currentActionFn = null;
             clearTimeout(TIMEOUT);
 
-            // get bot activity summary
-            let output = this.getBotOutputSummary();
-            let interrupted = this.agent.bot.interrupt_code;
-            let timedout = this.timedout;
+            const output = this.getBotOutputSummary();
+            const interrupted = this.agent.bot.interrupt_code;
+            const timedout = this.timedout;
             this.agent.clearBotLogs();
 
-            // if not interrupted and not generating, emit idle event
             if (!interrupted) {
                 this.agent.bot.emit('idle');
             }
 
-            // return action status report
             return { success: true, message: output, interrupted, timedout };
         } catch (err) {
             this.executing = false;
@@ -138,13 +152,13 @@ export class ActionManager {
 
             const errString = err instanceof Error ? err.toString() : String(err);
             const stack = err instanceof Error && err.stack ? err.stack : '';
-            let message = this.getBotOutputSummary() +
+            const message = this.getBotOutputSummary() +
                 '!!Code threw exception!!\n' +
                 'Error: ' + errString + '\n' +
                 'Stack trace:\n' + stack + '\n';
 
-            let interrupted = this.agent.bot.interrupt_code;
-            let timedout = this.timedout;
+            const interrupted = this.agent.bot.interrupt_code;
+            const timedout = this.timedout;
             this.agent.clearBotLogs();
             if (!interrupted) {
                 this.agent.bot.emit('idle');
@@ -174,8 +188,7 @@ export class ActionManager {
             console.warn(`Code execution timed out after ${TIMEOUT_MINS} minutes. Attempting force stop.`);
             this.timedout = true;
             this.agent.history.add('system', `Code execution timed out after ${TIMEOUT_MINS} minutes. Attempting force stop.`);
-            await this.stop(); // last attempt to stop
+            await this.stop();
         }, TIMEOUT_MINS * 60 * 1000);
     }
-
 }

--- a/src/agent/action_manager.js
+++ b/src/agent/action_manager.js
@@ -13,11 +13,11 @@ export class ActionManager {
         this.recent_action_counter = 0;
     }
 
-    async resumeAction(timeout) {
+    resumeAction(timeout) {
         return this._executeResume(null, null, timeout);
     }
 
-    async runAction(actionLabel, actionFn, { timeout, resume = false } = {}) {
+    runAction(actionLabel, actionFn, { timeout, resume = false } = {}) {
         if (resume) {
             return this._executeResume(actionLabel, actionFn, timeout);
         } else {

--- a/src/agent/action_manager.js
+++ b/src/agent/action_manager.js
@@ -1,3 +1,5 @@
+import assert from 'node:assert/strict';
+
 export class ActionManager {
     constructor(agent) {
         this.agent = agent;
@@ -11,8 +13,8 @@ export class ActionManager {
         this.recent_action_counter = 0;
     }
 
-    async resumeAction(actionFn, timeout) {
-        return this._executeResume(actionFn, timeout);
+    async resumeAction(timeout) {
+        return this._executeResume(null, null, timeout);
     }
 
     async runAction(actionLabel, actionFn, { timeout, resume = false } = {}) {
@@ -34,7 +36,7 @@ export class ActionManager {
             await new Promise(resolve => setTimeout(resolve, 300));
         }
         clearTimeout(timeout);
-    } 
+    }
 
     cancelResume() {
         this.resume_func = null;
@@ -60,6 +62,7 @@ export class ActionManager {
 
     async _executeAction(actionLabel, actionFn, timeout = 10) {
         let TIMEOUT;
+        this.timedout = false;
         try {
             if (this.last_action_time > 0) {
                 let time_diff = Date.now() - this.last_action_time;
@@ -129,23 +132,24 @@ export class ActionManager {
             this.currentActionFn = null;
             clearTimeout(TIMEOUT);
             this.cancelResume();
-            console.error("Code execution triggered catch:", err);
-            // Log the full stack trace
-            console.error(err.stack);
+            console.error('Code execution triggered catch:', err);
+            console.error(err?.stack);
             await this.stop();
-            err = err.toString();
 
+            const errString = err instanceof Error ? err.toString() : String(err);
+            const stack = err instanceof Error && err.stack ? err.stack : '';
             let message = this.getBotOutputSummary() +
                 '!!Code threw exception!!\n' +
-                'Error: ' + err + '\n' +
-                'Stack trace:\n' + err.stack+'\n';
+                'Error: ' + errString + '\n' +
+                'Stack trace:\n' + stack + '\n';
 
             let interrupted = this.agent.bot.interrupt_code;
+            let timedout = this.timedout;
             this.agent.clearBotLogs();
             if (!interrupted) {
                 this.agent.bot.emit('idle');
             }
-            return { success: false, message, interrupted, timedout: false };
+            return { success: false, message, interrupted, timedout };
         }
     }
 

--- a/src/utils/async_mutex.js
+++ b/src/utils/async_mutex.js
@@ -1,0 +1,31 @@
+export class AsyncMutex {
+    constructor() {
+        this.tail = Promise.resolve();
+        this.pending = 0;
+    }
+
+    async runExclusive(operation) {
+        if (typeof operation !== 'function') {
+            throw new TypeError('AsyncMutex operation must be a function.');
+        }
+
+        let release;
+        const previous = this.tail;
+        this.tail = new Promise(resolve => {
+            release = resolve;
+        });
+        this.pending++;
+
+        await previous;
+        try {
+            return await operation();
+        } finally {
+            this.pending--;
+            release();
+        }
+    }
+
+    isLocked() {
+        return this.pending > 0;
+    }
+}

--- a/tests/action_manager.test.js
+++ b/tests/action_manager.test.js
@@ -30,7 +30,7 @@ test('a previous timeout does not leak into the next action result', async () =>
     agent.actions = actions;
     actions.timedout = true;
 
-    const result = await actions.runAction('test', async () => {}, { timeout: -1 });
+    const result = await actions.runAction('test', () => Promise.resolve(), { timeout: -1 });
 
     assert.equal(result.success, true);
     assert.equal(result.timedout, false);

--- a/tests/action_manager.test.js
+++ b/tests/action_manager.test.js
@@ -1,0 +1,52 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import { ActionManager } from '../src/agent/action_manager.js';
+
+function makeAgent() {
+    const bot = new EventEmitter();
+    bot.output = '';
+    bot.interrupt_code = false;
+
+    return {
+        bot,
+        self_prompter: { isActive: () => false },
+        history: { add: () => {} },
+        isIdle() { return !this.actions?.executing; },
+        clearBotLogs() {
+            bot.output = '';
+            bot.interrupt_code = false;
+        },
+        requestInterrupt() {
+            bot.interrupt_code = true;
+        },
+        cleanKill() {}
+    };
+}
+
+test('a previous timeout does not leak into the next action result', async () => {
+    const agent = makeAgent();
+    const actions = new ActionManager(agent);
+    agent.actions = actions;
+    actions.timedout = true;
+
+    const result = await actions.runAction('test', async () => {}, { timeout: -1 });
+
+    assert.equal(result.success, true);
+    assert.equal(result.timedout, false);
+});
+
+test('thrown action errors preserve their stack trace', async () => {
+    const agent = makeAgent();
+    const actions = new ActionManager(agent);
+    agent.actions = actions;
+
+    const result = await actions.runAction('throwing', async () => {
+        throw new Error('boom');
+    }, { timeout: -1 });
+
+    assert.equal(result.success, false);
+    assert.match(result.message, /Error: boom/);
+    assert.match(result.message, /Stack trace:/);
+    assert.doesNotMatch(result.message, /Stack trace:\nundefined/);
+});

--- a/tests/action_manager.test.js
+++ b/tests/action_manager.test.js
@@ -52,3 +52,21 @@ test('thrown action errors preserve their stack trace', async () => {
     assert.match(result.message, /Stack trace:/);
     assert.doesNotMatch(result.message, /Stack trace:\nundefined/);
 });
+
+test('resumeAction reuses the stored resumable action', async () => {
+    const agent = makeAgent();
+    const actions = new ActionManager(agent);
+    agent.actions = actions;
+    let calls = 0;
+
+    const first = await actions.runAction(
+        'repeatable',
+        async () => { calls++; },
+        { timeout: -1, resume: true }
+    );
+    const resumed = await actions.resumeAction(-1);
+
+    assert.equal(first.success, true);
+    assert.equal(resumed.success, true);
+    assert.equal(calls, 2);
+});

--- a/tests/action_manager.test.js
+++ b/tests/action_manager.test.js
@@ -41,9 +41,11 @@ test('thrown action errors preserve their stack trace', async () => {
     const actions = new ActionManager(agent);
     agent.actions = actions;
 
-    const result = await actions.runAction('throwing', async () => {
-        throw new Error('boom');
-    }, { timeout: -1 });
+    const result = await actions.runAction(
+        'throwing',
+        () => Promise.reject(new Error('boom')),
+        { timeout: -1 }
+    );
 
     assert.equal(result.success, false);
     assert.match(result.message, /Error: boom/);

--- a/tests/action_manager_serialization.test.js
+++ b/tests/action_manager_serialization.test.js
@@ -47,7 +47,7 @@ test('ActionManager serializes concurrent runAction calls and interrupts the cur
         active--;
     };
 
-    const secondAction = async () => {
+    const secondAction = () => {
         active++;
         maxActive = Math.max(maxActive, active);
         events.push('b:start');

--- a/tests/action_manager_serialization.test.js
+++ b/tests/action_manager_serialization.test.js
@@ -1,0 +1,83 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { ActionManager } from '../src/agent/action_manager.js';
+
+const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+function createAgent() {
+    return {
+        interruptRequests: 0,
+        bot: {
+            output: '',
+            interrupt_code: null,
+            emit() {},
+        },
+        clearBotLogs() {
+            this.bot.output = '';
+            this.bot.interrupt_code = null;
+        },
+        requestInterrupt() {
+            this.interruptRequests++;
+            this.bot.interrupt_code = 'interrupted';
+        },
+        cleanKill() {
+            throw new Error('cleanKill should not be called in serialization test');
+        },
+        history: { add() {} },
+        isIdle() { return true; },
+        self_prompter: { isActive() { return false; } },
+    };
+}
+
+test('ActionManager serializes concurrent runAction calls and interrupts the current owner', async () => {
+    const agent = createAgent();
+    const manager = new ActionManager(agent);
+    const events = [];
+    let active = 0;
+    let maxActive = 0;
+
+    const firstAction = async () => {
+        active++;
+        maxActive = Math.max(maxActive, active);
+        events.push('a:start');
+        while (!agent.bot.interrupt_code) {
+            await delay(1);
+        }
+        events.push('a:end');
+        active--;
+    };
+
+    const secondAction = async () => {
+        active++;
+        maxActive = Math.max(maxActive, active);
+        events.push('b:start');
+        events.push('b:end');
+        active--;
+    };
+
+    const first = manager.runAction('a', firstAction, { timeout: 0 });
+    await delay(5);
+    const second = manager.runAction('b', secondAction, { timeout: 0 });
+    const [firstResult, secondResult] = await Promise.all([first, second]);
+
+    assert.equal(firstResult.success, true);
+    assert.equal(secondResult.success, true);
+    assert.equal(maxActive, 1);
+    assert.deepEqual(events, ['a:start', 'a:end', 'b:start', 'b:end']);
+    assert.ok(agent.interruptRequests >= 1);
+    assert.equal(manager.actionMutex.isLocked(), false);
+});
+
+test('concurrent stop calls share one stop operation', async () => {
+    const agent = createAgent();
+    const manager = new ActionManager(agent);
+    manager.executing = true;
+
+    setTimeout(() => {
+        manager.executing = false;
+    }, 20);
+
+    await Promise.all([manager.stop(), manager.stop(), manager.stop()]);
+    assert.equal(manager.stopPromise, null);
+    assert.ok(agent.interruptRequests >= 1);
+});

--- a/tests/async_mutex.test.js
+++ b/tests/async_mutex.test.js
@@ -1,0 +1,35 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { AsyncMutex } from '../src/utils/async_mutex.js';
+
+const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+test('AsyncMutex serializes concurrent operations in arrival order', async () => {
+    const mutex = new AsyncMutex();
+    const events = [];
+
+    await Promise.all([
+        mutex.runExclusive(async () => {
+            events.push('a:start');
+            await delay(20);
+            events.push('a:end');
+        }),
+        mutex.runExclusive(async () => {
+            events.push('b:start');
+            events.push('b:end');
+        }),
+    ]);
+
+    assert.deepEqual(events, ['a:start', 'a:end', 'b:start', 'b:end']);
+    assert.equal(mutex.isLocked(), false);
+});
+
+test('AsyncMutex releases ownership after a thrown operation', async () => {
+    const mutex = new AsyncMutex();
+    await assert.rejects(mutex.runExclusive(async () => {
+        throw new Error('boom');
+    }), /boom/);
+
+    const value = await mutex.runExclusive(async () => 42);
+    assert.equal(value, 42);
+});

--- a/tests/async_mutex.test.js
+++ b/tests/async_mutex.test.js
@@ -14,7 +14,7 @@ test('AsyncMutex serializes concurrent operations in arrival order', async () =>
             await delay(20);
             events.push('a:end');
         }),
-        mutex.runExclusive(async () => {
+        mutex.runExclusive(() => {
             events.push('b:start');
             events.push('b:end');
         }),
@@ -26,10 +26,10 @@ test('AsyncMutex serializes concurrent operations in arrival order', async () =>
 
 test('AsyncMutex releases ownership after a thrown operation', async () => {
     const mutex = new AsyncMutex();
-    await assert.rejects(mutex.runExclusive(async () => {
+    await assert.rejects(mutex.runExclusive(() => {
         throw new Error('boom');
     }), /boom/);
 
-    const value = await mutex.runExclusive(async () => 42);
+    const value = await mutex.runExclusive(() => 42);
     assert.equal(value, 42);
 });


### PR DESCRIPTION
## Merge status

**BLOCKED BY:** #64

Merge the blocking PR(s) first so GitHub can collapse the duplicated dependency commits from this stacked PR.

## Summary

Serialize ActionManager state ownership while preserving the action-state correctness fixes already proposed in #64.

## Changes

- Preserve the timeout reset, corrected resume signature, `assert` import, and thrown-error stack diagnostics from #64.
- Add FIFO async-mutex ownership around action and resume execution.
- Preserve the existing behavior where a newly requested action interrupts the current action before taking ownership.
- Deduplicate concurrent `stop()` callers with a shared stop operation.
- Guarantee mutex release after both success and thrown errors.
- Add concurrency tests proving actions never overlap.

## Why

`executing`, current action metadata, timeout state, bot logs, and resume state are shared mutable action state. Without central ownership, concurrent callers can race after waiting for the previous action and overwrite each other's state.

## Validation

Fork PR CI passes on the reconciled #64 + serialization stack.

## Dependencies

Depends on #64. Until #64 lands, this PR intentionally contains the combined reconciled diff. After #64 merges, GitHub should collapse this to the serialization delta.