### PR TITLE
Validate and freeze per-agent configuration

### DIFF
--- a/src/agent/mindserver_proxy.js
+++ b/src/agent/mindserver_proxy.js
@@ -1,7 +1,6 @@
 import { io } from 'socket.io-client';
-import convoManager from './conversation.js';
 import { setSettings } from './settings.js';
-import { getFullState } from './library/full_state.js';
+import rootSettings from '../../settings.js';
 
 // agent's individual connection to the mindserver
 // always connect to localhost
@@ -11,30 +10,66 @@ class MindServerProxy {
         if (MindServerProxy.instance) {
             return MindServerProxy.instance;
         }
-        
+
         this.socket = null;
         this.connected = false;
         this.agents = [];
+        this.convoManager = null;
+        this.getFullState = null;
         MindServerProxy.instance = this;
     }
 
     async connect(name, port) {
         if (this.connected) return;
-        
+
         this.name = name;
         this.socket = io(`http://localhost:${port}`);
 
         await new Promise((resolve, reject) => {
-            this.socket.on('connect', resolve);
-            this.socket.on('connect_error', (err) => {
-                console.error('Connection failed:', err);
-                reject(err);
+            this.socket.once('connect', resolve);
+            this.socket.once('connect_error', reject);
+        });
+
+        // Load this process's per-agent settings before importing the Agent
+        // runtime. Several runtime modules snapshot settings during module
+        // evaluation, so importing them before this handshake can freeze the
+        // root/default values instead of the settings for this agent.
+        const response = await new Promise((resolve, reject) => {
+            const timeout = setTimeout(() => {
+                reject(new Error('Settings request timed out after 5 seconds'));
+            }, 5000);
+
+            this.socket.emit('get-settings', name, (settingsResponse) => {
+                clearTimeout(timeout);
+                if (settingsResponse.error) {
+                    reject(new Error(settingsResponse.error));
+                    return;
+                }
+                resolve(settingsResponse);
             });
         });
 
+        setSettings(response.settings);
+        Object.assign(rootSettings, response.settings);
+
+        // conversation.js and full_state.js pull in commands/skills/mcdata. Delay
+        // both import chains until after the settings handshake has populated
+        // the child-process settings objects.
+        const [{ default: convoManager }, { getFullState }] = await Promise.all([
+            import('./conversation.js'),
+            import('./library/full_state.js'),
+        ]);
+        this.convoManager = convoManager;
+        this.getFullState = getFullState;
+
+        this._registerSocketHandlers();
         this.connected = true;
         console.log(name, 'connected to MindServer');
 
+        this.socket.emit('connect-agent-process', name);
+    }
+
+    _registerSocketHandlers() {
         this.socket.on('disconnect', () => {
             console.log('Disconnected from MindServer');
             this.connected = false;
@@ -44,12 +79,12 @@ class MindServerProxy {
         });
 
         this.socket.on('chat-message', (agentName, json) => {
-            convoManager.receiveFromBot(agentName, json);
+            this.convoManager.receiveFromBot(agentName, json);
         });
 
         this.socket.on('agents-status', (agents) => {
             this.agents = agents;
-            convoManager.updateAgents(agents);
+            this.convoManager.updateAgents(agents);
             if (this.agent?.task) {
                 console.log(this.agent.name, 'updating available agents');
                 this.agent.task.updateAvailableAgents(agents);
@@ -58,12 +93,12 @@ class MindServerProxy {
 
         this.socket.on('restart-agent', (agentName) => {
             console.log(`Restarting agent: ${agentName}`);
-            this.agent.cleanKill();
+            this.agent?.cleanKill();
         });
-		
+
         this.socket.on('send-message', (data) => {
             try {
-                this.agent.respondFunc(data.from, data.message);
+                this.agent?.respondFunc(data.from, data.message);
             } catch (error) {
                 console.error('Error: ', JSON.stringify(error, Object.getOwnPropertyNames(error)));
             }
@@ -71,29 +106,16 @@ class MindServerProxy {
 
         this.socket.on('get-full-state', (callback) => {
             try {
-                const state = getFullState(this.agent);
+                if (!this.agent || !this.getFullState) {
+                    callback(null);
+                    return;
+                }
+                const state = this.getFullState(this.agent);
                 callback(state);
             } catch (error) {
                 console.error('Error getting full state:', error);
                 callback(null);
             }
-        });
-
-        // Request settings and wait for response
-        await new Promise((resolve, reject) => {
-            const timeout = setTimeout(() => {
-                reject(new Error('Settings request timed out after 5 seconds'));
-            }, 5000);
-
-            this.socket.emit('get-settings', name, (response) => {
-                clearTimeout(timeout);
-                if (response.error) {
-                    return reject(new Error(response.error));
-                }
-                setSettings(response.settings);
-                this.socket.emit('connect-agent-process', name);
-                resolve();
-            });
         });
     }
 

--- a/src/mindcraft/agent_config.js
+++ b/src/mindcraft/agent_config.js
@@ -1,0 +1,23 @@
+import { readFileSync } from 'node:fs';
+import { createAgentConfig, deepFreeze } from '../utils/config.js';
+
+const settingsSpec = JSON.parse(
+    readFileSync(new URL('./public/settings_spec.json', import.meta.url), 'utf8')
+);
+
+const ROOT_ONLY_SETTINGS = new Set([
+    'profiles',
+    'mindserver_port',
+    'auto_open_ui',
+]);
+
+export function validateAgentSettings(settings) {
+    const agentSettings = Object.fromEntries(
+        Object.entries(settings).filter(([key]) => !ROOT_ONLY_SETTINGS.has(key))
+    );
+    return createAgentConfig(agentSettings, settingsSpec);
+}
+
+export function freezeResolvedAgentSettings(settings) {
+    return deepFreeze(structuredClone(settings));
+}

--- a/src/mindcraft/agent_config.js
+++ b/src/mindcraft/agent_config.js
@@ -11,11 +11,29 @@ const ROOT_ONLY_SETTINGS = new Set([
     'auto_open_ui',
 ]);
 
+const AGENT_NAME_PATTERN = /^[a-zA-Z0-9_]{3,16}$/;
+
+export function normalizeAgentName(name) {
+    if (typeof name !== 'string') {
+        throw new TypeError('Agent name must be a string.');
+    }
+    const normalized = name.trim();
+    if (!AGENT_NAME_PATTERN.test(normalized)) {
+        throw new Error(`Invalid agent name '${name}'. Must be 3-16 alphanumeric/underscore characters.`);
+    }
+    return normalized;
+}
+
 export function validateAgentSettings(settings) {
     const agentSettings = Object.fromEntries(
         Object.entries(settings).filter(([key]) => !ROOT_ONLY_SETTINGS.has(key))
     );
-    return createAgentConfig(agentSettings, settingsSpec);
+    const config = structuredClone(createAgentConfig(agentSettings, settingsSpec));
+    if (!config.profile || typeof config.profile !== 'object' || Array.isArray(config.profile)) {
+        throw new TypeError('Agent profile must be an object.');
+    }
+    config.profile.name = normalizeAgentName(config.profile.name);
+    return deepFreeze(config);
 }
 
 export function freezeResolvedAgentSettings(settings) {

--- a/src/mindcraft/mindcraft.js
+++ b/src/mindcraft/mindcraft.js
@@ -1,6 +1,7 @@
 import { createMindServer, registerAgent, numStateListeners } from './mindserver.js';
 import { AgentProcess } from '../process/agent_process.js';
 import { getServer } from './mcserver.js';
+import { freezeResolvedAgentSettings, validateAgentSettings } from './agent_config.js';
 import open from 'open';
 
 let mindserver;
@@ -19,7 +20,6 @@ export async function init(host_public=false, port=8080, auto_open_ui=true) {
     connected = true;
     if (auto_open_ui) {
         setTimeout(() => {
-            // check if browser listener is already open
             if (numStateListeners() === 0) {
                 open('http://localhost:'+port);
             }
@@ -27,21 +27,31 @@ export async function init(host_public=false, port=8080, auto_open_ui=true) {
     }
 }
 
-export async function createAgent(settings) {
-    if (!settings.profile.name) {
+export async function createAgent(inputSettings) {
+    let settings;
+    try {
+        settings = structuredClone(validateAgentSettings(inputSettings));
+    } catch (error) {
+        console.error('Invalid agent settings:', error.message);
+        return {
+            success: false,
+            error: error.message,
+        };
+    }
+
+    if (!settings.profile?.name || typeof settings.profile.name !== 'string') {
         console.error('Agent name is required in profile');
         return {
             success: false,
             error: 'Agent name is required in profile'
         };
     }
-    settings = JSON.parse(JSON.stringify(settings));
-    let agent_name = settings.profile.name;
+
+    const agent_name = settings.profile.name;
     const agentIndex = agent_count++;
     const viewer_port = 3000 + agentIndex;
-    registerAgent(settings, viewer_port);
-    let load_memory = settings.load_memory || false;
-    let init_message = settings.init_message || null;
+    const load_memory = settings.load_memory || false;
+    const init_message = settings.init_message || null;
 
     try {
         try {
@@ -50,16 +60,19 @@ export async function createAgent(settings) {
             settings.port = server.port;
             settings.minecraft_version = server.version;
         } catch (error) {
-            console.warn(`Error getting server:`, error);
-            if (settings.minecraft_version === "auto") {
+            console.warn('Error getting server:', error);
+            if (settings.minecraft_version === 'auto') {
                 settings.minecraft_version = null;
             }
-            console.warn(`Attempting to connect anyway...`);
+            console.warn('Attempting to connect anyway...');
         }
+
+        const resolvedSettings = freezeResolvedAgentSettings(settings);
+        registerAgent(resolvedSettings, viewer_port);
 
         const agentProcess = new AgentProcess(agent_name, mindserver_port);
         agentProcess.start(load_memory, init_message, agentIndex);
-        agent_processes[settings.profile.name] = agentProcess;
+        agent_processes[resolvedSettings.profile.name] = agentProcess;
     } catch (error) {
         console.error(`Error creating agent ${agent_name}:`, error);
         destroyAgent(agent_name);
@@ -102,7 +115,7 @@ export function destroyAgent(agentName) {
 
 export function shutdown() {
     console.log('Shutting down');
-    for (let agentName in agent_processes) {
+    for (const agentName in agent_processes) {
         agent_processes[agentName].stop();
     }
     setTimeout(() => {

--- a/src/mindcraft/public/settings_spec.json
+++ b/src/mindcraft/public/settings_spec.json
@@ -119,13 +119,18 @@
     },
     "allow_insecure_coding": {
         "type": "boolean",
-        "description": "Whether to allow newAction command that let's LLM write/run code on host computer. Despite sandboxxing, it is potentially insecure.",
+        "description": "Whether to allow newAction command that lets LLM write/run code on host computer. Despite sandboxing, it is potentially insecure.",
         "default": false
     },
     "code_timeout_mins": {
         "type": "number",
         "description": "Number of minutes to allow code execution. -1 for no timeout",
         "default": -1
+    },
+    "block_place_delay": {
+        "type": "number",
+        "description": "Delay in milliseconds between block placements for generated actions.",
+        "default": 0
     },
     "task": {
         "type": "object",

--- a/src/process/init_agent.js
+++ b/src/process/init_agent.js
@@ -36,7 +36,7 @@ const argv = yargs(args)
     })
     .argv;
 
-(async () => {
+await (async () => {
     try {
         console.log('Connecting to MindServer');
         await serverProxy.connect(argv.name, argv.port);

--- a/src/process/init_agent.js
+++ b/src/process/init_agent.js
@@ -1,4 +1,3 @@
-import { Agent } from '../agent/agent.js';
 import { serverProxy } from '../agent/mindserver_proxy.js';
 import yargs from 'yargs';
 
@@ -41,6 +40,12 @@ const argv = yargs(args)
     try {
         console.log('Connecting to MindServer');
         await serverProxy.connect(argv.name, argv.port);
+
+        // Import Agent only after connect() has received this process's settings.
+        // Agent's dependency graph includes modules that read settings at module
+        // initialization time.
+        const { Agent } = await import('../agent/agent.js');
+
         console.log('Starting agent');
         const agent = new Agent();
         serverProxy.setAgent(agent);

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -1,0 +1,76 @@
+function cloneValue(value) {
+    if (value === undefined) return undefined;
+    return structuredClone(value);
+}
+
+function matchesType(value, type) {
+    switch (type) {
+        case 'array': return Array.isArray(value);
+        case 'object': return value !== null && typeof value === 'object' && !Array.isArray(value);
+        case 'number': return typeof value === 'number' && Number.isFinite(value);
+        case 'boolean': return typeof value === 'boolean';
+        case 'string': return typeof value === 'string';
+        default: throw new Error(`Unsupported settings schema type: ${type}`);
+    }
+}
+
+function isNullable(definition) {
+    return definition?.nullable === true || definition?.default === null;
+}
+
+export function validateSettings(settings, spec, { allowUnknown = false, applyDefaults = true } = {}) {
+    if (settings === null || typeof settings !== 'object' || Array.isArray(settings)) {
+        throw new TypeError('Settings must be an object.');
+    }
+    if (spec === null || typeof spec !== 'object' || Array.isArray(spec)) {
+        throw new TypeError('Settings specification must be an object.');
+    }
+
+    const result = {};
+
+    for (const [key, definition] of Object.entries(spec)) {
+        let value = settings[key];
+        if (value === undefined && applyDefaults && Object.prototype.hasOwnProperty.call(definition, 'default')) {
+            value = cloneValue(definition.default);
+        }
+
+        if (value === undefined) {
+            if (definition.required) throw new Error(`Setting ${key} is required.`);
+            continue;
+        }
+
+        if (value === null && isNullable(definition)) {
+            result[key] = null;
+            continue;
+        }
+
+        if (definition.type && !matchesType(value, definition.type)) {
+            throw new TypeError(`Setting ${key} must be of type ${definition.type}.`);
+        }
+        if (definition.options && !definition.options.includes(value)) {
+            throw new Error(`Setting ${key} must be one of: ${definition.options.join(', ')}.`);
+        }
+
+        result[key] = cloneValue(value);
+    }
+
+    const unknown = Object.keys(settings).filter(key => !(key in spec));
+    if (!allowUnknown && unknown.length > 0) {
+        throw new Error(`Unknown settings: ${unknown.join(', ')}.`);
+    }
+    if (allowUnknown) {
+        for (const key of unknown) result[key] = cloneValue(settings[key]);
+    }
+
+    return result;
+}
+
+export function deepFreeze(value) {
+    if (value === null || typeof value !== 'object' || Object.isFrozen(value)) return value;
+    for (const child of Object.values(value)) deepFreeze(child);
+    return Object.freeze(value);
+}
+
+export function createAgentConfig(settings, spec, options) {
+    return deepFreeze(validateSettings(settings, spec, options));
+}

--- a/tests/agent_config.test.js
+++ b/tests/agent_config.test.js
@@ -1,0 +1,29 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { validateAgentSettings } from '../src/mindcraft/agent_config.js';
+
+test('validateAgentSettings accepts root launcher keys but excludes them from agent config', () => {
+    const config = validateAgentSettings({
+        profile: { name: 'Andy' },
+        profiles: ['./andy.json'],
+        mindserver_port: 8080,
+        auto_open_ui: true,
+        block_place_delay: 25,
+    });
+
+    assert.equal(config.profile.name, 'Andy');
+    assert.equal(config.block_place_delay, 25);
+    assert.equal(config.task, null);
+    assert.equal('profiles' in config, false);
+    assert.equal('mindserver_port' in config, false);
+    assert.equal('auto_open_ui' in config, false);
+    assert.equal(Object.isFrozen(config), true);
+    assert.equal(Object.isFrozen(config.profile), true);
+});
+
+test('validateAgentSettings still rejects unknown per-agent settings', () => {
+    assert.throws(() => validateAgentSettings({
+        profile: { name: 'Andy' },
+        typo_setting: true,
+    }), /Unknown settings/);
+});

--- a/tests/agent_config.test.js
+++ b/tests/agent_config.test.js
@@ -1,10 +1,10 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { validateAgentSettings } from '../src/mindcraft/agent_config.js';
+import { normalizeAgentName, validateAgentSettings } from '../src/mindcraft/agent_config.js';
 
 test('validateAgentSettings accepts root launcher keys but excludes them from agent config', () => {
     const config = validateAgentSettings({
-        profile: { name: 'Andy' },
+        profile: { name: ' Andy ' },
         profiles: ['./andy.json'],
         mindserver_port: 8080,
         auto_open_ui: true,
@@ -19,6 +19,19 @@ test('validateAgentSettings accepts root launcher keys but excludes them from ag
     assert.equal('auto_open_ui' in config, false);
     assert.equal(Object.isFrozen(config), true);
     assert.equal(Object.isFrozen(config.profile), true);
+});
+
+test('agent names are normalized and reject path/control syntax before runtime use', () => {
+    assert.equal(normalizeAgentName(' Test_Bot '), 'Test_Bot');
+    assert.throws(() => normalizeAgentName('../bots'), /Invalid agent name/);
+    assert.throws(() => normalizeAgentName('a/b'), /Invalid agent name/);
+    assert.throws(() => normalizeAgentName('bad\nname'), /Invalid agent name/);
+    assert.throws(() => normalizeAgentName('ab'), /Invalid agent name/);
+    assert.throws(() => normalizeAgentName(123), /must be a string/);
+
+    assert.throws(() => validateAgentSettings({
+        profile: { name: '../escape' },
+    }), /Invalid agent name/);
 });
 
 test('validateAgentSettings still rejects unknown per-agent settings', () => {

--- a/tests/config_validation.test.js
+++ b/tests/config_validation.test.js
@@ -1,0 +1,37 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createAgentConfig, validateSettings } from '../src/utils/config.js';
+
+const spec = {
+    enabled: { type: 'boolean', default: false },
+    port: { type: 'number', required: true },
+    mode: { type: 'string', options: ['safe', 'fast'], default: 'safe' },
+    names: { type: 'array', default: [] },
+    task: { type: 'object', default: null },
+};
+
+test('validateSettings applies defaults and enforces declared types/options', () => {
+    assert.deepEqual(validateSettings({ port: 8080 }, spec), {
+        enabled: false,
+        port: 8080,
+        mode: 'safe',
+        names: [],
+        task: null,
+    });
+    assert.throws(() => validateSettings({ port: '8080' }, spec), /type number/);
+    assert.throws(() => validateSettings({ port: 8080, mode: 'unsafe' }, spec), /must be one of/);
+});
+
+test('validateSettings rejects unknown keys by default', () => {
+    assert.throws(() => validateSettings({ port: 8080, surprise: true }, spec), /Unknown settings/);
+});
+
+test('createAgentConfig deeply freezes a validated copy', () => {
+    const input = { port: 8080, names: ['Andy'] };
+    const config = createAgentConfig(input, spec);
+    input.names.push('MutatedLater');
+
+    assert.deepEqual(config.names, ['Andy']);
+    assert.equal(Object.isFrozen(config), true);
+    assert.equal(Object.isFrozen(config.names), true);
+});


### PR DESCRIPTION
## Merge status

**BLOCKED BY:** #75

Merge the blocking PR(s) first so GitHub can collapse the duplicated dependency commits from this stacked PR.

## Summary

Validate, normalize, and freeze per-agent configuration before registration or process spawn.

## Changes

- Add schema-backed type/default/enum/required/unknown-key validation.
- Handle nullable settings such as `task: null`.
- Exclude launcher-only keys from per-agent validation.
- Restore `block_place_delay` to the settings schema.
- Validate configuration before agent registration and child-process spawn.
- Normalize and validate agent names before they can reach filesystem/path-sensitive code.
- Restrict agent names to safe Minecraft-compatible characters and length.
- Reject path traversal, control characters, and invalid names.
- Resolve server details on a working copy rather than mutating the caller-owned configuration.
- Deep-freeze the resolved runtime configuration.
- Add regression tests for validation, cloning, defaults, nullability, name safety, and immutability.

## Why

Runtime modules consume per-agent settings in multiple places, including import-time paths. Invalid or mutable configuration can create cross-agent drift, while an unvalidated profile name can reach filesystem operations.

## Validation

Fork CI passes on the reconciled #75 + validated-config stack.

## Dependencies

Depends on #75 so each child receives its validated settings before runtime modules are imported.