### PR TITLE
Introduce bounded fail-closed structured command parsing

### DIFF
--- a/src/agent/commands/index.js
+++ b/src/agent/commands/index.js
@@ -139,6 +139,7 @@ export function parseCommandMessage(message) {
             case 'ItemName':
                 if (arg.endsWith('plank') || arg.endsWith('seed'))
                     arg += 's'; // add 's' to for common mistakes like "oak_plank" or "wheat_seed"
+                break;
             case 'string':
                 break;
             default:

--- a/src/agent/commands/index.js
+++ b/src/agent/commands/index.js
@@ -46,7 +46,7 @@ export function containsCommand(message) {
         const parsed = parseStructuredCommand(message);
         if (parsed) return parsed.commandName;
     } catch {
-        // Preserve command detection for malformed or legacy-formatted commands.
+        // Command presence is still useful for routing an eventual parse error.
     }
     const commandMatch = message.match(commandNameRegex);
     if (commandMatch)
@@ -174,15 +174,17 @@ export function parseCommandMessage(message) {
         return `Command exceeds maximum length of ${structuredCommandLimits.maxLength} characters.`;
 
     let parsed = null;
-    let structuredError = null;
     try {
         parsed = parseStructuredCommand(message);
     } catch (error) {
-        structuredError = error;
+        // If a command uses parenthesized structured syntax but its arguments are
+        // malformed, fail closed. Falling back here can reinterpret e.g.
+        // !stop(foo) as a valid zero-argument !stop command.
+        return error instanceof Error ? error.message : 'Command is incorrectly formatted';
     }
 
     if (!parsed) parsed = parseLegacyCommand(message);
-    if (!parsed) return structuredError?.message || 'Command is incorrectly formatted';
+    if (!parsed) return 'Command is incorrectly formatted';
 
     const { commandName } = parsed;
     const args = [...parsed.args];
@@ -209,7 +211,8 @@ export function truncCommandMessage(message) {
         try {
             return truncateToStructuredCommand(message);
         } catch {
-            // Fall back to the established regex boundary for legacy/malformed syntax.
+            // Preserve the original malformed command for parseCommandMessage to reject.
+            return message;
         }
     }
     const commandMatch = message.match(commandRegex);

--- a/src/agent/commands/index.js
+++ b/src/agent/commands/index.js
@@ -1,12 +1,13 @@
-import { getBlockId, getItemId } from "../../utils/mcdata.js";
+import { getBlockId, getItemId } from '../../utils/mcdata.js';
 import { actionsList } from './actions.js';
 import { queryList } from './queries.js';
+import { normalizePlacementItemName } from './placement_aliases.js';
 
 let suppressNoDomainWarning = true;
 
 const commandList = queryList.concat(actionsList);
 const commandMap = {};
-for (let command of commandList) {
+for (const command of commandList) {
     commandMap[command.name] = command;
 }
 
@@ -16,8 +17,8 @@ export function getCommand(name) {
 
 export function blacklistCommands(commands) {
     const unblockable = ['!stop', '!stats', '!inventory', '!goal'];
-    for (let command_name of commands) {
-        if (unblockable.includes(command_name)){
+    for (const command_name of commands) {
+        if (unblockable.includes(command_name)) {
             console.warn(`Command ${command_name} is unblockable`);
             continue;
         }
@@ -36,29 +37,24 @@ const argRegex = /-?\d+(?:\.\d+)?|true|false|"[^"]*"/g;
 export function containsCommand(message) {
     const commandMatch = message.match(commandRegex);
     if (commandMatch)
-        return "!" + commandMatch[1];
+        return '!' + commandMatch[1];
     return null;
 }
 
 export function commandExists(commandName) {
-    if (!commandName.startsWith("!"))
-        commandName = "!" + commandName;
+    if (!commandName.startsWith('!'))
+        commandName = '!' + commandName;
     return commandMap[commandName] !== undefined;
 }
 
-/**
- * Converts a string into a boolean.
- * @param {string} input
- * @returns {boolean | null} the boolean or `null` if it could not be parsed.
- * */
 function parseBoolean(input) {
     switch(input.toLowerCase()) {
-        case 'false': //These are interpreted as flase;
+        case 'false':
         case 'f':
         case '0':
         case 'off':
             return false;
-        case 'true': //These are interpreted as true;
+        case 'true':
         case 't':
         case '1':
         case 'on':
@@ -68,113 +64,87 @@ function parseBoolean(input) {
     }
 }
 
-/**
- * @param {number} value - the value to check
- * @param {number} lowerBound
- * @param {number} upperBound
- * @param {string} endpointType - The type of the endpoints represented as a two character string. `'[)'` `'()'` 
- */
 function checkInInterval(number, lowerBound, upperBound, endpointType) {
     switch (endpointType) {
-        case '[)':
-            return lowerBound <= number && number < upperBound;
-        case '()':
-            return lowerBound < number && number < upperBound;
-        case '(]':
-            return lowerBound < number && number <= upperBound;
-        case '[]':
-            return lowerBound <= number && number <= upperBound;
-        default:
-            throw new Error('Unknown endpoint type:', endpointType);
+        case '[)': return lowerBound <= number && number < upperBound;
+        case '()': return lowerBound < number && number < upperBound;
+        case '(]': return lowerBound < number && number <= upperBound;
+        case '[]': return lowerBound <= number && number <= upperBound;
+        default: throw new Error(`Unknown endpoint type: ${endpointType}`);
     }
 }
 
-
-
-// todo: handle arrays?
-/**
- * Returns an object containing the command, the command name, and the comand parameters.
- * If parsing unsuccessful, returns an error message as a string.
- * @param {string} message - A message from a player or language model containing a command.
- * @returns {string | Object}
- */
 export function parseCommandMessage(message) {
     const commandMatch = message.match(commandRegex);
-    if (!commandMatch) return `Command is incorrectly formatted`;
+    if (!commandMatch) return 'Command is incorrectly formatted';
 
-    const commandName = "!"+commandMatch[1];
-
-    let args;
-    if (commandMatch[2]) args = commandMatch[2].match(argRegex);
-    else args = [];
+    const commandName = '!' + commandMatch[1];
+    let args = commandMatch[2] ? commandMatch[2].match(argRegex) : [];
 
     const command = getCommand(commandName);
-    if(!command) return `${commandName} is not a command.`;
+    if (!command) return `${commandName} is not a command.`;
 
     const params = commandParams(command);
     const paramNames = commandParamNames(command);
-    
     if (args.length !== params.length)
         return `Command ${command.name} was given ${args.length} args, but requires ${params.length} args.`;
 
-    
     for (let i = 0; i < args.length; i++) {
         const param = params[i];
-        //Remove any extra characters
         let arg = args[i].trim();
         if ((arg.startsWith('"') && arg.endsWith('"')) || (arg.startsWith("'") && arg.endsWith("'"))) {
-            arg = arg.substring(1, arg.length-1);
+            arg = arg.substring(1, arg.length - 1);
         }
-        
-        //Convert to the correct type
+
+        if (commandName === '!placeHere' && param.type === 'BlockOrItemName') {
+            arg = normalizePlacementItemName(arg);
+        }
+
         switch(param.type) {
             case 'int':
-                arg = Number.parseInt(arg); break;
+                arg = Number.parseInt(arg);
+                break;
             case 'float':
-                arg = Number.parseFloat(arg); break;
+                arg = Number.parseFloat(arg);
+                break;
             case 'boolean':
-                arg = parseBoolean(arg); break;
+                arg = parseBoolean(arg);
+                break;
             case 'BlockName':
             case 'BlockOrItemName':
             case 'ItemName':
                 if (arg.endsWith('plank') || arg.endsWith('seed'))
-                    arg += 's'; // add 's' to for common mistakes like "oak_plank" or "wheat_seed"
+                    arg += 's';
                 break;
             case 'string':
                 break;
             default:
                 throw new Error(`Command '${commandName}' parameter '${paramNames[i]}' has an unknown type: ${param.type}`);
         }
-        if(arg === null || Number.isNaN(arg))
+        if (arg === null || Number.isNaN(arg))
             return `Error: Param '${paramNames[i]}' must be of type ${param.type}.`;
 
-        if(typeof arg === 'number') { //Check the domain of numbers
+        if (typeof arg === 'number') {
             const domain = param.domain;
-            if(domain) {
-                /**
-                 * Javascript has a built in object for sets but not intervals.
-                 * Currently the interval (lowerbound,upperbound] is represented as an Array: `[lowerbound, upperbound, '(]']`
-                 */
-                if (!domain[2]) domain[2] = '[)'; //By default, lower bound is included. Upper is not.
-
-                if(!checkInInterval(arg, ...domain)) {
-                    return `Error: Param '${paramNames[i]}' must be an element of ${domain[2][0]}${domain[0]}, ${domain[1]}${domain[2][1]}.`;
-                    //Alternatively arg could be set to the nearest value in the domain.
+            if (domain) {
+                const endpointType = domain[2] || '[)';
+                if (!checkInInterval(arg, domain[0], domain[1], endpointType)) {
+                    return `Error: Param '${paramNames[i]}' must be an element of ${endpointType[0]}${domain[0]}, ${domain[1]}${endpointType[1]}.`;
                 }
             } else if (!suppressNoDomainWarning) {
                 console.warn(`Command '${commandName}' parameter '${paramNames[i]}' has no domain set. Expect any value [-Infinity, Infinity].`);
-                suppressNoDomainWarning = true; //Don't spam console. Only give the warning once.
+                suppressNoDomainWarning = true;
             }
-        } else if(param.type === 'BlockName') { //Check that there is a block with this name
-            if(getBlockId(arg) == null) return  `Invalid block type: ${arg}.`;
-        } else if(param.type === 'ItemName') { //Check that there is an item with this name
-            if(getItemId(arg) == null) return `Invalid item type: ${arg}.`;
-        } else if(param.type === 'BlockOrItemName') {
-            if(getBlockId(arg) == null && getItemId(arg) == null) return  `Invalid block or item type: ${arg}.`;
+        } else if (param.type === 'BlockName') {
+            if (getBlockId(arg) == null) return `Invalid block type: ${arg}.`;
+        } else if (param.type === 'ItemName') {
+            if (getItemId(arg) == null) return `Invalid item type: ${arg}.`;
+        } else if (param.type === 'BlockOrItemName') {
+            if (getBlockId(arg) == null && getItemId(arg) == null) return `Invalid block or item type: ${arg}.`;
         }
         args[i] = arg;
     }
-    
+
     return { commandName, args };
 }
 
@@ -190,20 +160,12 @@ export function isAction(name) {
     return actionsList.find(action => action.name === name) !== undefined;
 }
 
-/**
- * @param {Object} command
- * @returns {Object[]} The command's parameters.
- */
 function commandParams(command) {
     if (!command.params)
         return [];
     return Object.values(command.params);
 }
 
-/**
- * @param {Object} command
- * @returns {string[]} The names of the command's parameters.
- */
 function commandParamNames(command) {
     if (!command.params)
         return [];
@@ -215,48 +177,37 @@ function numParams(command) {
 }
 
 export async function executeCommand(agent, message) {
-    let parsed = parseCommandMessage(message);
+    const parsed = parseCommandMessage(message);
     if (typeof parsed === 'string')
-        return parsed; //The command was incorrectly formatted or an invalid input was given.
-    else {
-        console.log('parsed command:', parsed);
-        const command = getCommand(parsed.commandName);
-        let numArgs = 0;
-        if (parsed.args) {
-            numArgs = parsed.args.length;
-        }
-        if (numArgs !== numParams(command))
-            return `Command ${command.name} was given ${numArgs} args, but requires ${numParams(command)} args.`;
-        else {
-            const result = await command.perform(agent, ...parsed.args);
-            return result;
-        }
-    }
+        return parsed;
+
+    console.log('parsed command:', parsed);
+    const command = getCommand(parsed.commandName);
+    const numArgs = parsed.args?.length || 0;
+    if (numArgs !== numParams(command))
+        return `Command ${command.name} was given ${numArgs} args, but requires ${numParams(command)} args.`;
+    return command.perform(agent, ...parsed.args);
 }
 
 export function getCommandDocs(agent) {
     const typeTranslations = {
-        //This was added to keep the prompt the same as before type checks were implemented.
-        //If the language model is giving invalid inputs changing this might help.
-        'float':             'number',
-        'int':               'number',
-        'BlockName':         'string',
-        'ItemName':          'string',
-        'BlockOrItemName':   'string',
-        'boolean':           'bool'
+        float: 'number',
+        int: 'number',
+        BlockName: 'string',
+        ItemName: 'string',
+        BlockOrItemName: 'string',
+        boolean: 'bool'
     };
-    let docs = `\n*COMMAND DOCS\n You can use the following commands to perform actions and get information about the world. 
-    Use the commands with the syntax: !commandName or !commandName("arg1", 1.2, ...) if the command takes arguments.\n
-    Do not use codeblocks. Use double quotes for strings. Only use one command in each response, trailing commands and comments will be ignored.\n`;
-    for (let command of commandList) {
+    let docs = `\n*COMMAND DOCS\n You can use the following commands to perform actions and get information about the world. \n    Use the commands with the syntax: !commandName or !commandName("arg1", 1.2, ...) if the command takes arguments.\n\n    Do not use codeblocks. Use double quotes for strings. Only use one command in each response, trailing commands and comments will be ignored.\n`;
+    for (const command of commandList) {
         if (agent.blocked_actions.includes(command.name)) {
             continue;
         }
         docs += command.name + ': ' + command.description + '\n';
         if (command.params) {
             docs += 'Params:\n';
-            for (let param in command.params) {
-                docs += `${param}: (${typeTranslations[command.params[param].type]??command.params[param].type}) ${command.params[param].description}\n`;
+            for (const param in command.params) {
+                docs += `${param}: (${typeTranslations[command.params[param].type] ?? command.params[param].type}) ${command.params[param].description}\n`;
             }
         }
     }

--- a/src/agent/commands/index.js
+++ b/src/agent/commands/index.js
@@ -2,6 +2,11 @@ import { getBlockId, getItemId } from '../../utils/mcdata.js';
 import { actionsList } from './actions.js';
 import { queryList } from './queries.js';
 import { normalizePlacementItemName } from './placement_aliases.js';
+import {
+    parseStructuredCommand,
+    structuredCommandLimits,
+    truncateToStructuredCommand,
+} from './structured_parser.js';
 
 let suppressNoDomainWarning = true;
 
@@ -33,9 +38,17 @@ export function blacklistCommands(commands) {
 
 const commandRegex = /!(\w+)(?:\(((?:-?\d+(?:\.\d+)?|true|false|"[^"]*")(?:\s*,\s*(?:-?\d+(?:\.\d+)?|true|false|"[^"]*"))*)\))?/;
 const argRegex = /-?\d+(?:\.\d+)?|true|false|"[^"]*"/g;
+const commandNameRegex = /!(\w+)/;
 
 export function containsCommand(message) {
-    const commandMatch = message.match(commandRegex);
+    if (typeof message !== 'string') return null;
+    try {
+        const parsed = parseStructuredCommand(message);
+        if (parsed) return parsed.commandName;
+    } catch {
+        // Preserve command detection for malformed or legacy-formatted commands.
+    }
+    const commandMatch = message.match(commandNameRegex);
     if (commandMatch)
         return '!' + commandMatch[1];
     return null;
@@ -48,7 +61,7 @@ export function commandExists(commandName) {
 }
 
 function parseBoolean(input) {
-    switch(input.toLowerCase()) {
+    switch(String(input).toLowerCase()) {
         case 'false':
         case 'f':
         case '0':
@@ -74,13 +87,105 @@ function checkInInterval(number, lowerBound, upperBound, endpointType) {
     }
 }
 
-export function parseCommandMessage(message) {
+function parseLegacyCommand(message) {
     const commandMatch = message.match(commandRegex);
-    if (!commandMatch) return 'Command is incorrectly formatted';
+    if (!commandMatch) return null;
+    return {
+        commandName: '!' + commandMatch[1],
+        args: commandMatch[2] ? commandMatch[2].match(argRegex) : [],
+    };
+}
 
-    const commandName = '!' + commandMatch[1];
-    let args = commandMatch[2] ? commandMatch[2].match(argRegex) : [];
+function convertArgument(arg, param, paramName, commandName) {
+    let value = arg;
+    if (typeof value === 'string') {
+        value = value.trim();
+        if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+            value = value.substring(1, value.length - 1);
+        }
+    }
 
+    if (commandName === '!placeHere' && param.type === 'BlockOrItemName' && typeof value === 'string') {
+        value = normalizePlacementItemName(value);
+    }
+
+    switch(param.type) {
+        case 'int':
+            value = Number.parseInt(String(value));
+            break;
+        case 'float':
+            value = Number.parseFloat(String(value));
+            break;
+        case 'boolean':
+            if (typeof value !== 'boolean') value = parseBoolean(value);
+            break;
+        case 'BlockName':
+        case 'BlockOrItemName':
+        case 'ItemName':
+            if (typeof value !== 'string')
+                return { error: `Error: Param '${paramName}' must be of type ${param.type}.` };
+            if (value.endsWith('plank') || value.endsWith('seed'))
+                value += 's';
+            break;
+        case 'string':
+            if (typeof value !== 'string')
+                return { error: `Error: Param '${paramName}' must be of type ${param.type}.` };
+            break;
+        case 'array':
+            if (!Array.isArray(value))
+                return { error: `Error: Param '${paramName}' must be of type array.` };
+            break;
+        case 'object':
+            if (value === null || typeof value !== 'object' || Array.isArray(value))
+                return { error: `Error: Param '${paramName}' must be of type object.` };
+            break;
+        default:
+            throw new Error(`Command '${commandName}' parameter '${paramName}' has an unknown type: ${param.type}`);
+    }
+
+    if (value === null || Number.isNaN(value))
+        return { error: `Error: Param '${paramName}' must be of type ${param.type}.` };
+
+    if (typeof value === 'number') {
+        const domain = param.domain;
+        if (domain) {
+            const endpointType = domain[2] || '[)';
+            if (!checkInInterval(value, domain[0], domain[1], endpointType)) {
+                return { error: `Error: Param '${paramName}' must be an element of ${endpointType[0]}${domain[0]}, ${domain[1]}${endpointType[1]}.` };
+            }
+        } else if (!suppressNoDomainWarning) {
+            console.warn(`Command '${commandName}' parameter '${paramName}' has no domain set. Expect any value [-Infinity, Infinity].`);
+            suppressNoDomainWarning = true;
+        }
+    } else if (param.type === 'BlockName') {
+        if (getBlockId(value) == null) return { error: `Invalid block type: ${value}.` };
+    } else if (param.type === 'ItemName') {
+        if (getItemId(value) == null) return { error: `Invalid item type: ${value}.` };
+    } else if (param.type === 'BlockOrItemName') {
+        if (getBlockId(value) == null && getItemId(value) == null) return { error: `Invalid block or item type: ${value}.` };
+    }
+
+    return { value };
+}
+
+export function parseCommandMessage(message) {
+    if (typeof message !== 'string') return 'Command is incorrectly formatted';
+    if (message.length > structuredCommandLimits.maxLength)
+        return `Command exceeds maximum length of ${structuredCommandLimits.maxLength} characters.`;
+
+    let parsed = null;
+    let structuredError = null;
+    try {
+        parsed = parseStructuredCommand(message);
+    } catch (error) {
+        structuredError = error;
+    }
+
+    if (!parsed) parsed = parseLegacyCommand(message);
+    if (!parsed) return structuredError?.message || 'Command is incorrectly formatted';
+
+    const { commandName } = parsed;
+    const args = [...parsed.args];
     const command = getCommand(commandName);
     if (!command) return `${commandName} is not a command.`;
 
@@ -90,65 +195,23 @@ export function parseCommandMessage(message) {
         return `Command ${command.name} was given ${args.length} args, but requires ${params.length} args.`;
 
     for (let i = 0; i < args.length; i++) {
-        const param = params[i];
-        let arg = args[i].trim();
-        if ((arg.startsWith('"') && arg.endsWith('"')) || (arg.startsWith("'") && arg.endsWith("'"))) {
-            arg = arg.substring(1, arg.length - 1);
-        }
-
-        if (commandName === '!placeHere' && param.type === 'BlockOrItemName') {
-            arg = normalizePlacementItemName(arg);
-        }
-
-        switch(param.type) {
-            case 'int':
-                arg = Number.parseInt(arg);
-                break;
-            case 'float':
-                arg = Number.parseFloat(arg);
-                break;
-            case 'boolean':
-                arg = parseBoolean(arg);
-                break;
-            case 'BlockName':
-            case 'BlockOrItemName':
-            case 'ItemName':
-                if (arg.endsWith('plank') || arg.endsWith('seed'))
-                    arg += 's';
-                break;
-            case 'string':
-                break;
-            default:
-                throw new Error(`Command '${commandName}' parameter '${paramNames[i]}' has an unknown type: ${param.type}`);
-        }
-        if (arg === null || Number.isNaN(arg))
-            return `Error: Param '${paramNames[i]}' must be of type ${param.type}.`;
-
-        if (typeof arg === 'number') {
-            const domain = param.domain;
-            if (domain) {
-                const endpointType = domain[2] || '[)';
-                if (!checkInInterval(arg, domain[0], domain[1], endpointType)) {
-                    return `Error: Param '${paramNames[i]}' must be an element of ${endpointType[0]}${domain[0]}, ${domain[1]}${endpointType[1]}.`;
-                }
-            } else if (!suppressNoDomainWarning) {
-                console.warn(`Command '${commandName}' parameter '${paramNames[i]}' has no domain set. Expect any value [-Infinity, Infinity].`);
-                suppressNoDomainWarning = true;
-            }
-        } else if (param.type === 'BlockName') {
-            if (getBlockId(arg) == null) return `Invalid block type: ${arg}.`;
-        } else if (param.type === 'ItemName') {
-            if (getItemId(arg) == null) return `Invalid item type: ${arg}.`;
-        } else if (param.type === 'BlockOrItemName') {
-            if (getBlockId(arg) == null && getItemId(arg) == null) return `Invalid block or item type: ${arg}.`;
-        }
-        args[i] = arg;
+        const converted = convertArgument(args[i], params[i], paramNames[i], commandName);
+        if (converted.error) return converted.error;
+        args[i] = converted.value;
     }
 
     return { commandName, args };
 }
 
 export function truncCommandMessage(message) {
+    if (typeof message !== 'string') return message;
+    if (message.length <= structuredCommandLimits.maxLength) {
+        try {
+            return truncateToStructuredCommand(message);
+        } catch {
+            // Fall back to the established regex boundary for legacy/malformed syntax.
+        }
+    }
     const commandMatch = message.match(commandRegex);
     if (commandMatch) {
         return message.substring(0, commandMatch.index + commandMatch[0].length);
@@ -161,14 +224,12 @@ export function isAction(name) {
 }
 
 function commandParams(command) {
-    if (!command.params)
-        return [];
+    if (!command.params) return [];
     return Object.values(command.params);
 }
 
 function commandParamNames(command) {
-    if (!command.params)
-        return [];
+    if (!command.params) return [];
     return Object.keys(command.params);
 }
 
@@ -178,8 +239,7 @@ function numParams(command) {
 
 export async function executeCommand(agent, message) {
     const parsed = parseCommandMessage(message);
-    if (typeof parsed === 'string')
-        return parsed;
+    if (typeof parsed === 'string') return parsed;
 
     console.log('parsed command:', parsed);
     const command = getCommand(parsed.commandName);
@@ -200,9 +260,7 @@ export function getCommandDocs(agent) {
     };
     let docs = `\n*COMMAND DOCS\n You can use the following commands to perform actions and get information about the world. \n    Use the commands with the syntax: !commandName or !commandName("arg1", 1.2, ...) if the command takes arguments.\n\n    Do not use codeblocks. Use double quotes for strings. Only use one command in each response, trailing commands and comments will be ignored.\n`;
     for (const command of commandList) {
-        if (agent.blocked_actions.includes(command.name)) {
-            continue;
-        }
+        if (agent.blocked_actions.includes(command.name)) continue;
         docs += command.name + ': ' + command.description + '\n';
         if (command.params) {
             docs += 'Params:\n';

--- a/src/agent/commands/index.js
+++ b/src/agent/commands/index.js
@@ -30,7 +30,7 @@ export function blacklistCommands(commands) {
     }
 }
 
-const commandRegex = /!(\w+)(?:\(((?:-?\d+(?:\.\d+)?|true|false|"[^"]*")(?:\s*,\s*(?:-?\d+(?:\.\d+)?|true|false|"[^"]*"))*)\))?/
+const commandRegex = /!(\w+)(?:\(((?:-?\d+(?:\.\d+)?|true|false|"[^"]*")(?:\s*,\s*(?:-?\d+(?:\.\d+)?|true|false|"[^"]*"))*)\))?/;
 const argRegex = /-?\d+(?:\.\d+)?|true|false|"[^"]*"/g;
 
 export function containsCommand(message) {
@@ -85,7 +85,7 @@ function checkInInterval(number, lowerBound, upperBound, endpointType) {
         case '[]':
             return lowerBound <= number && number <= upperBound;
         default:
-            throw new Error('Unknown endpoint type:', endpointType)
+            throw new Error('Unknown endpoint type:', endpointType);
     }
 }
 
@@ -109,7 +109,7 @@ export function parseCommandMessage(message) {
     else args = [];
 
     const command = getCommand(commandName);
-    if(!command) return `${commandName} is not a command.`
+    if(!command) return `${commandName} is not a command.`;
 
     const params = commandParams(command);
     const paramNames = commandParamNames(command);
@@ -145,7 +145,7 @@ export function parseCommandMessage(message) {
                 throw new Error(`Command '${commandName}' parameter '${paramNames[i]}' has an unknown type: ${param.type}`);
         }
         if(arg === null || Number.isNaN(arg))
-            return `Error: Param '${paramNames[i]}' must be of type ${param.type}.`
+            return `Error: Param '${paramNames[i]}' must be of type ${param.type}.`;
 
         if(typeof arg === 'number') { //Check the domain of numbers
             const domain = param.domain;
@@ -161,15 +161,15 @@ export function parseCommandMessage(message) {
                     //Alternatively arg could be set to the nearest value in the domain.
                 }
             } else if (!suppressNoDomainWarning) {
-                console.warn(`Command '${commandName}' parameter '${paramNames[i]}' has no domain set. Expect any value [-Infinity, Infinity].`)
+                console.warn(`Command '${commandName}' parameter '${paramNames[i]}' has no domain set. Expect any value [-Infinity, Infinity].`);
                 suppressNoDomainWarning = true; //Don't spam console. Only give the warning once.
             }
         } else if(param.type === 'BlockName') { //Check that there is a block with this name
-            if(getBlockId(arg) == null) return  `Invalid block type: ${arg}.`
+            if(getBlockId(arg) == null) return  `Invalid block type: ${arg}.`;
         } else if(param.type === 'ItemName') { //Check that there is an item with this name
-            if(getItemId(arg) == null) return `Invalid item type: ${arg}.`
+            if(getItemId(arg) == null) return `Invalid item type: ${arg}.`;
         } else if(param.type === 'BlockOrItemName') {
-            if(getBlockId(arg) == null && getItemId(arg) == null) return  `Invalid block or item type: ${arg}.`
+            if(getBlockId(arg) == null && getItemId(arg) == null) return  `Invalid block or item type: ${arg}.`;
         }
         args[i] = arg;
     }
@@ -243,7 +243,7 @@ export function getCommandDocs(agent) {
         'ItemName':          'string',
         'BlockOrItemName':   'string',
         'boolean':           'bool'
-    }
+    };
     let docs = `\n*COMMAND DOCS\n You can use the following commands to perform actions and get information about the world. 
     Use the commands with the syntax: !commandName or !commandName("arg1", 1.2, ...) if the command takes arguments.\n
     Do not use codeblocks. Use double quotes for strings. Only use one command in each response, trailing commands and comments will be ignored.\n`;

--- a/src/agent/commands/index.js
+++ b/src/agent/commands/index.js
@@ -21,8 +21,12 @@ export function blacklistCommands(commands) {
             console.warn(`Command ${command_name} is unblockable`);
             continue;
         }
+
         delete commandMap[command_name];
-        delete commandList.find(command => command.name === command_name);
+        const index = commandList.findIndex(command => command.name === command_name);
+        if (index !== -1) {
+            commandList.splice(index, 1);
+        }
     }
 }
 

--- a/src/agent/commands/placement_aliases.js
+++ b/src/agent/commands/placement_aliases.js
@@ -1,0 +1,9 @@
+const PLACEMENT_ITEM_ALIASES = Object.freeze({
+    tripwire: 'string',
+    potatoes: 'potato',
+    wheat: 'wheat_seeds',
+});
+
+export function normalizePlacementItemName(name) {
+    return PLACEMENT_ITEM_ALIASES[name] ?? name;
+}

--- a/src/agent/commands/structured_parser.js
+++ b/src/agent/commands/structured_parser.js
@@ -1,0 +1,97 @@
+const MAX_COMMAND_LENGTH = 16 * 1024;
+const MAX_NESTING_DEPTH = 32;
+
+function assertInputSize(text) {
+    if (text.length > MAX_COMMAND_LENGTH) {
+        throw new SyntaxError(`Command exceeds maximum length of ${MAX_COMMAND_LENGTH} characters.`);
+    }
+}
+
+function assertValueDepth(value, depth = 0) {
+    if (depth > MAX_NESTING_DEPTH) {
+        throw new SyntaxError(`Command arguments exceed maximum nesting depth of ${MAX_NESTING_DEPTH}.`);
+    }
+    if (value === null || typeof value !== 'object') return;
+    for (const child of Array.isArray(value) ? value : Object.values(value)) {
+        assertValueDepth(child, depth + 1);
+    }
+}
+
+function findClosingParen(text, openIndex) {
+    let depth = 0;
+    let inString = false;
+    let escaped = false;
+
+    for (let i = openIndex; i < text.length; i++) {
+        const char = text[i];
+        if (inString) {
+            if (escaped) {
+                escaped = false;
+            } else if (char === '\\') {
+                escaped = true;
+            } else if (char === '"') {
+                inString = false;
+            }
+            continue;
+        }
+
+        if (char === '"') {
+            inString = true;
+        } else if (char === '(') {
+            depth++;
+        } else if (char === ')') {
+            depth--;
+            if (depth === 0) return i;
+        }
+    }
+
+    throw new SyntaxError('Command is missing a closing parenthesis.');
+}
+
+export function parseStructuredCommand(message) {
+    if (typeof message !== 'string') throw new TypeError('Command message must be a string.');
+    assertInputSize(message);
+
+    const match = /!(\w+)/.exec(message);
+    if (!match) return null;
+
+    const commandName = `!${match[1]}`;
+    const start = match.index;
+    let cursor = start + match[0].length;
+    while (/\s/.test(message[cursor] ?? '')) cursor++;
+
+    if (message[cursor] !== '(') {
+        return { commandName, args: [], start, end: cursor };
+    }
+
+    const close = findClosingParen(message, cursor);
+    const rawArgs = message.slice(cursor + 1, close).trim();
+    let args = [];
+
+    if (rawArgs) {
+        try {
+            args = JSON.parse(`[${rawArgs}]`);
+        } catch (error) {
+            throw new SyntaxError(`Invalid command arguments: ${error.message}`, { cause: error });
+        }
+        assertValueDepth(args);
+    }
+
+    return {
+        commandName,
+        args,
+        start,
+        end: close + 1,
+    };
+}
+
+export function truncateToStructuredCommand(message) {
+    const parsed = parseStructuredCommand(message);
+    if (!parsed) return message;
+    return message.slice(0, parsed.end);
+}
+
+export const structuredCommandLimits = Object.freeze({
+    maxLength: MAX_COMMAND_LENGTH,
+    maxDepth: MAX_NESTING_DEPTH,
+});

--- a/tests/command_blacklist.test.js
+++ b/tests/command_blacklist.test.js
@@ -1,0 +1,12 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { blacklistCommands, commandExists, getCommandDocs } from '../src/agent/commands/index.js';
+
+test('blacklisting removes a command from lookup and generated docs', () => {
+    assert.equal(commandExists('!nearbyBlocks'), true);
+    blacklistCommands(['!nearbyBlocks']);
+    assert.equal(commandExists('!nearbyBlocks'), false);
+
+    const docs = getCommandDocs({ blocked_actions: [] });
+    assert.doesNotMatch(docs, /!nearbyBlocks/);
+});

--- a/tests/command_parser_integration.test.js
+++ b/tests/command_parser_integration.test.js
@@ -34,6 +34,13 @@ test('command detection and truncation use structured command boundaries', () =>
     assert.equal(truncCommandMessage(message), 'do this !rememberHere("a, b")');
 });
 
+test('malformed structured arguments fail closed instead of becoming a different legacy command', () => {
+    const malformed = '!stop(foo)';
+    assert.equal(containsCommand(malformed), '!stop');
+    assert.match(parseCommandMessage(malformed), /Invalid command arguments/);
+    assert.equal(truncCommandMessage(malformed), malformed);
+});
+
 test('integrated command parsing rejects oversized input', () => {
     const oversized = '!rememberHere("' + 'x'.repeat(structuredCommandLimits.maxLength) + '")';
     assert.match(parseCommandMessage(oversized), /exceeds maximum length/);

--- a/tests/command_parser_integration.test.js
+++ b/tests/command_parser_integration.test.js
@@ -1,0 +1,40 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+    containsCommand,
+    parseCommandMessage,
+    truncCommandMessage,
+} from '../src/agent/commands/index.js';
+import { structuredCommandLimits } from '../src/agent/commands/structured_parser.js';
+
+test('command parsing accepts escaped structured strings and validates against command schema', () => {
+    const parsed = parseCommandMessage('prefix !rememberHere("home, \\"base\\"") trailing');
+    assert.deepEqual(parsed, {
+        commandName: '!rememberHere',
+        args: ['home, "base"'],
+    });
+});
+
+test('structured numeric arguments retain existing command domain validation', () => {
+    const parsed = parseCommandMessage('!goToCoordinates(1.5, 64, -3, 2)');
+    assert.deepEqual(parsed, {
+        commandName: '!goToCoordinates',
+        args: [1.5, 64, -3, 2],
+    });
+
+    assert.match(
+        parseCommandMessage('!goToCoordinates(1, 400, 3, 1)'),
+        /must be an element/
+    );
+});
+
+test('command detection and truncation use structured command boundaries', () => {
+    const message = 'do this !rememberHere("a, b") and ignore this !stop';
+    assert.equal(containsCommand(message), '!rememberHere');
+    assert.equal(truncCommandMessage(message), 'do this !rememberHere("a, b")');
+});
+
+test('integrated command parsing rejects oversized input', () => {
+    const oversized = '!rememberHere("' + 'x'.repeat(structuredCommandLimits.maxLength) + '")';
+    assert.match(parseCommandMessage(oversized), /exceeds maximum length/);
+});

--- a/tests/placement_aliases.test.js
+++ b/tests/placement_aliases.test.js
@@ -1,0 +1,13 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { normalizePlacementItemName } from '../src/agent/commands/placement_aliases.js';
+
+test('placeHere aliases normalize block registry names to inventory item names', () => {
+    assert.equal(normalizePlacementItemName('tripwire'), 'string');
+    assert.equal(normalizePlacementItemName('potatoes'), 'potato');
+    assert.equal(normalizePlacementItemName('wheat'), 'wheat_seeds');
+});
+
+test('unknown placement names pass through unchanged', () => {
+    assert.equal(normalizePlacementItemName('oak_planks'), 'oak_planks');
+});

--- a/tests/structured_command_parser.test.js
+++ b/tests/structured_command_parser.test.js
@@ -1,0 +1,34 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+    parseStructuredCommand,
+    truncateToStructuredCommand,
+} from '../src/agent/commands/structured_parser.js';
+
+test('structured parser handles quoted commas and escaped quotes', () => {
+    const parsed = parseStructuredCommand('prefix !say("hello, \\"world\\"") trailing');
+    assert.equal(parsed.commandName, '!say');
+    assert.deepEqual(parsed.args, ['hello, "world"']);
+});
+
+test('structured parser supports nested JSON values', () => {
+    const parsed = parseStructuredCommand('!configure({"mode":"safe","coords":[1,2,3]}, true, -4.5)');
+    assert.deepEqual(parsed.args, [
+        { mode: 'safe', coords: [1, 2, 3] },
+        true,
+        -4.5,
+    ]);
+});
+
+test('structured parser preserves command boundaries for truncation', () => {
+    const message = 'I will act !goToCoordinates(1, 2, 3, 1) and then explain more';
+    assert.equal(
+        truncateToStructuredCommand(message),
+        'I will act !goToCoordinates(1, 2, 3, 1)'
+    );
+});
+
+test('structured parser rejects malformed argument syntax', () => {
+    assert.throws(() => parseStructuredCommand('!say("unterminated)'));
+    assert.throws(() => parseStructuredCommand('!say(foo)'));
+});


### PR DESCRIPTION
## Merge status

**BLOCKED BY:** #62, #65

Merge the blocking PR(s) first so GitHub can collapse the duplicated dependency commits from this stacked PR.

## Summary

Route command parsing through a bounded structured parser while preserving command-registry compatibility.

## Changes

- Preserve #65 blacklist removal from lookup and generated command documentation.
- Preserve #62 `!placeHere` registry-to-inventory aliases.
- Parse JSON-compatible strings, booleans, numbers, arrays, objects, escapes, quoted commas, and nested values.
- Cap command input at 16 KiB.
- Cap structured nesting depth at 32.
- Feed parsed values through the existing type/domain/block/item validation.
- Preserve exact command boundaries used by response truncation.
- Keep legacy parsing available for genuinely legacy/unstructured command syntax.
- Fail closed when input is clearly intended to be structured but is malformed.
- Do not reinterpret malformed structured commands through the legacy parser.
- Explicitly reject regressions such as `!stop(foo)` being reinterpreted as bare `!stop`.
- Add integration coverage for valid structured input, malformed input, limits, aliases, blacklist behavior, and numeric domains.

## Why

Structured input needs predictable parsing semantics. Falling back after a structured parse failure can change the meaning of malformed commands and accidentally invoke a different command shape.

## Validation

Fork CI passes on the reconciled #62 + #65 + structured-parser stack.

## Dependencies

Depends on #62 and #65.